### PR TITLE
DataCite xml to Schema.org JSONLD transform

### DIFF
--- a/DataCite2SDO/DataCiteToSchemaOrgDataset.xslt
+++ b/DataCite2SDO/DataCiteToSchemaOrgDataset.xslt
@@ -1,0 +1,1219 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    exclude-result-prefixes="xs" version="1.0">
+
+    <!-- 
+  Transform to map content from standard xml metadata formats to 
+  Schema.org JSON-LD for @type=Dataset. The design uses a set of 
+  xsl variables and templates to do the mapping from the xml document
+  to the appropriate JSON-LD content. To configure for new metadata
+  scheme, update the code to extract needed information in the appropriate
+  variables and templates.
+  Note that each template has a set of variables as well.
+  
+  Note that namespace delarations might need to be added on the root
+   stylesheet element for other metadata schemes. This transform is designed
+   to handle DataCiteXML
+    
+    
+  Stephen M. Richard
+    2017-01-14
+ -->
+
+    <xsl:output method="text" indent="yes" encoding="UTF-8"/>
+
+    <!-- xpath testing for the root element in the xml document (near line 729) needs to be 
+     updated in the base template match statement to adapt for other
+     metadata formats. -->
+
+    <xsl:template match="//*[local-name() = 'creators']">
+
+        <!-- returns JSON array of schema.org Person objects -->
+        <xsl:text>[</xsl:text>
+        <xsl:for-each select="*[local-name() = 'creator']">
+            <!-- handle each person in the creatorList -->
+            <xsl:variable name="personID">
+                <xsl:variable name="theids" select="*[local-name() = 'nameIdentifier']"/>
+                <xsl:choose>
+                    <!-- add tests for other identifier schemes here... -->
+                    <xsl:when test="count($theids[@nameIdentifierScheme = 'ORCID']) &gt; 0"
+                            >http://orcid.org/<xsl:value-of
+                            select="$theids[@nameIdentifierScheme = 'ORCID'][1]"/>
+                    </xsl:when>
+                    <xsl:when test="count($theids[@nameIdentifierScheme = 'ISNI']) &gt; 0"
+                            >http://isni.org/isni/<xsl:value-of
+                            select="$theids[@nameIdentifierScheme = 'ISNI'][1]"/>
+                    </xsl:when>
+                    <xsl:when test="count($theids[@nameIdentifierScheme = 'SCOPUS']) &gt; 0"
+                            >https://www.scopus.com/authid/detail.uri?authorId=<xsl:value-of
+                            select="$theids[@nameIdentifierScheme = 'SCOPUS'][1]"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:variable name="test1">
+                            <xsl:for-each select="$theids">
+                                <xsl:if test="starts-with(., 'http://')">
+                                    <xsl:value-of select="."/>
+                                    <!-- if there is more than one http id, will 
+									take the last one it checks... -->
+                                </xsl:if>
+                            </xsl:for-each>
+                        </xsl:variable>
+                        <xsl:choose>
+                            <xsl:when test="$test1 = ''">
+                                <xsl:value-of select="string('')"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="$test1"/>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+            <xsl:variable name="personName">
+                <xsl:choose>
+                    <xsl:when test="normalize-space(*[local-name() = 'creatorName']) != ''">
+                        <xsl:value-of select="normalize-space(*[local-name() = 'creatorName'])"/>
+                    </xsl:when>
+                    <xsl:when test="normalize-space(*[local-name() = 'familyName']) != ''">
+                        <xsl:value-of
+                            select="
+                                concat(normalize-space(*[local-name() = 'givenName']),
+                                ' ', normalize-space(*[local-name() = 'familyName']))"
+                        />
+                    </xsl:when>
+
+                    <xsl:otherwise>
+                        <xsl:value-of select="string('missing')"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+            <xsl:text>{
+                "@type": "Person",
+                "additionalType": "geolink:Person",&#10;</xsl:text>
+            <xsl:if test="$personID and string-length($personID) > 0">
+                <xsl:text>      "@id": "</xsl:text>
+                <xsl:value-of select="$personID"/>
+                <xsl:text>",&#10;</xsl:text>
+            </xsl:if>
+            <xsl:text>      "name": "</xsl:text>
+            <xsl:value-of select="$personName"/>
+            <xsl:text>"</xsl:text>
+            <xsl:if test="*[local-name() = 'givenName']">
+                <xsl:text>,&#10;      "givenName": "</xsl:text>
+                <xsl:value-of select="*[local-name() = 'givenName']"/>
+                <xsl:text>"</xsl:text>
+            </xsl:if>
+            <xsl:if test="*[local-name() = 'familyName']">
+                <xsl:text>,&#10;      "familyName": "</xsl:text>
+                <xsl:value-of select="*[local-name() = 'familyName']"/>
+                <xsl:text>"</xsl:text>
+            </xsl:if>
+
+            <!-- more content might be available; insert here -->
+
+            <xsl:text>}</xsl:text>
+            <xsl:if test="following-sibling::*[local-name() = 'creator']">
+                <xsl:text>,&#10;</xsl:text>
+            </xsl:if>
+        </xsl:for-each>
+        <xsl:text>]</xsl:text>
+    </xsl:template>
+
+    <xsl:template name="distributions">
+        <!-- returns list of schema.org DataDownload JSON objects -->
+        <!-- first check if there are any access URLs. If there is a DOI, then
+        the DOI should resolve to landing page; other links  to get data might be 
+        in alternate identifiers-->
+        <xsl:variable name="datacite-identifier" select="//*[local-name() = 'identifier']"/>
+        <xsl:variable name="encodingFormat">
+            <xsl:if test="//*[local-name() = 'format']">
+                <xsl:text>      "encodingFormat": </xsl:text>
+                <xsl:choose>
+                    <xsl:when test="count(//*[local-name() = 'format']) = 1">
+                        <xsl:text>"</xsl:text>
+                        <xsl:value-of select="//*[local-name() = 'format']"/>
+                        <xsl:text>"</xsl:text>
+                    </xsl:when>
+                    <xsl:when test="count(//*[local-name() = 'format']) > 1">
+                        <xsl:text>[</xsl:text>
+                        <xsl:for-each select="//*[local-name() = 'format']">
+                            <xsl:text>"</xsl:text>
+                            <xsl:value-of select="normalize-space(text())"/>
+                            <xsl:text>"</xsl:text>
+                            <xsl:if test="following-sibling::*[local-name() = 'format']">
+                                <xsl:text>, </xsl:text>
+                            </xsl:if>
+                        </xsl:for-each>
+                        <xsl:text>]</xsl:text>
+                    </xsl:when>
+                </xsl:choose>
+            </xsl:if>
+        </xsl:variable>
+        <xsl:if test="($datacite-identifier and $datacite-identifier/@identifierType = 'DOI')">
+            <xsl:text>{&#10;    "@type": "DataDownload",&#10;    "additionalType": "dcat:distribution",&#10;</xsl:text>
+            <xsl:text>      "name":"DOI landing page",&#10;</xsl:text>
+            <xsl:variable name="theURL">
+                <xsl:choose>
+                    <xsl:when test="starts-with($datacite-identifier, 'doi:')">
+                        <xsl:value-of
+                            select="concat('http://dx.doi.org/', substring-after($datacite-identifier, 'doi:'))"
+                        />
+                    </xsl:when>
+                    <xsl:when test="$datacite-identifier/@identifierType = 'DOI'">
+                        <xsl:value-of
+                            select="concat('http://dx.doi.org/', normalize-space($datacite-identifier))"
+                        />
+                    </xsl:when>
+                    <xsl:when test="starts-with($datacite-identifier, 'http://')">
+                        <xsl:value-of select="$datacite-identifier"/>
+                    </xsl:when>
+                    <xsl:otherwise> http://missing.org </xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+
+            <xsl:text>      "dcat:accessURL": "</xsl:text>
+            <xsl:value-of select="$theURL"/>
+            <xsl:text>",&#10;</xsl:text>
+
+            <xsl:text>      "url": "</xsl:text>
+            <xsl:value-of select="$theURL"/>
+            <xsl:text>"</xsl:text>
+            <xsl:if test="string-length($encodingFormat) > 0">
+                <xsl:text>,&#10;</xsl:text>
+                <xsl:value-of select="$encodingFormat"/>
+            </xsl:if>
+            <xsl:text>}</xsl:text>
+            <xsl:if test="//*[local-name() = 'alternateIdentifier' and starts-with(., 'http')]">
+                <xsl:text>,&#10;</xsl:text>
+            </xsl:if>
+        </xsl:if>
+        <xsl:if test="//*[local-name() = 'alternateIdentifier' and starts-with(., 'http')]">
+            <xsl:for-each
+                select="//*[local-name() = 'alternateIdentifier' and starts-with(., 'http')]">
+                <xsl:text>{&#10;</xsl:text>
+                <xsl:text>    "@type": "DataDownload",&#10;    "additionalType": "dcat:distribution",&#10;</xsl:text>
+                <xsl:text>      "name":"</xsl:text>
+                <xsl:value-of select="@alternateIdentifierType"/>
+                <xsl:text>",&#10;</xsl:text>
+                <xsl:text>      "dcat:accessURL": "</xsl:text>
+                <xsl:value-of select="normalize-space(text())"/>
+                <xsl:text>",&#10;</xsl:text>
+
+                <xsl:text>      "url": "</xsl:text>
+                <xsl:value-of select="normalize-space(text())"/>
+                <xsl:text>"&#10;</xsl:text>
+                <xsl:if test="string-length($encodingFormat) > 0">
+                    <xsl:text>,&#10;</xsl:text>
+                    <xsl:value-of select="$encodingFormat"/>
+                </xsl:if>
+
+                <!-- more content might be available; insert here -->
+
+                <xsl:text>}</xsl:text>
+                <xsl:if
+                    test="following-sibling::*[local-name() = 'alternateIdentifier' and starts-with(., 'http')]">
+                    <xsl:text>,&#10;</xsl:text>
+                </xsl:if>
+            </xsl:for-each>
+        </xsl:if>
+
+    </xsl:template>
+
+    <xsl:template name="identifiers">
+        <!-- returns list of schema.org identifier JSON objects -->
+        <xsl:variable name="datacite-identifier" select="//*[local-name() = 'identifier']"/>
+        <xsl:if test="($datacite-identifier and $datacite-identifier/@identifierType = 'DOI')">
+            <xsl:text>            {&#10;</xsl:text>
+            <xsl:text>                "@id": "</xsl:text>
+            <xsl:choose>
+                <xsl:when test="starts-with($datacite-identifier, 'doi:')">
+                    <xsl:value-of select="normalize-space($datacite-identifier)"/>
+                </xsl:when>
+                <xsl:when test="starts-with($datacite-identifier, 'http://')"> doi:<xsl:value-of
+                        select="substring-after($datacite-identifier, 'http://dx.doi.org/')"/>
+                </xsl:when>
+                <xsl:when test="$datacite-identifier/@identifierType = 'DOI'"> doi:<xsl:value-of
+                        select="normalize-space($datacite-identifier)"/>
+                </xsl:when>
+            </xsl:choose>
+            <xsl:text>",&#10;</xsl:text>
+
+            <xsl:text>               "@type": "PropertyValue",
+            "additionalType": ["geolink:Identifier", "datacite:Identifier"],
+            "propertyID": "datacite:doi",&#10;</xsl:text>
+            <xsl:variable name="theURL">
+                <xsl:choose>
+                    <xsl:when test="starts-with($datacite-identifier, 'doi:')">
+                        <xsl:value-of
+                            select="concat('http://dx.doi.org/', substring-after($datacite-identifier, 'doi:'))"
+                        />
+                    </xsl:when>
+                    <xsl:when test="$datacite-identifier/@identifierType = 'DOI'">
+                        <xsl:value-of
+                            select="concat('http://dx.doi.org/', normalize-space($datacite-identifier))"
+                        />
+                    </xsl:when>
+                    <xsl:when test="starts-with($datacite-identifier, 'http://')">
+                        <xsl:value-of select="$datacite-identifier"/>
+                    </xsl:when>
+                    <xsl:otherwise> http://missing.org </xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+
+            <xsl:text>      "url": "</xsl:text>
+            <xsl:value-of select="$theURL"/>
+            <xsl:text>",</xsl:text>
+
+            <xsl:text>      "value": "</xsl:text>
+            <xsl:choose>
+                <xsl:when test="starts-with($datacite-identifier, 'doi:')">
+                    <xsl:value-of select="substring-after($datacite-identifier, 'doi:')"/>
+                </xsl:when>
+                <xsl:when test="starts-with($datacite-identifier, 'http://')">
+                    <xsl:value-of
+                        select="substring-after($datacite-identifier, 'http://dx.doi.org/')"/>
+                </xsl:when>
+                <xsl:when test="$datacite-identifier/@identifierType = 'DOI'">
+                    <xsl:value-of select="normalize-space($datacite-identifier)"/>
+                </xsl:when>
+            </xsl:choose>
+            <xsl:text>"}</xsl:text>
+
+            <xsl:if
+                test="count(//*[local-name() = 'alternateIdentifier' and not(starts-with(., 'http'))]) > 0">
+                <xsl:text>,&#10;</xsl:text>
+            </xsl:if>
+        </xsl:if>
+
+        <!-- now handle alaternate identifiers -->
+
+        <xsl:for-each
+            select="//*[local-name() = 'alternateIdentifier' and not(starts-with(., 'http'))]">
+            <xsl:text>{&#10;</xsl:text>
+            <xsl:text>                "@id": "</xsl:text>
+            <xsl:value-of select="normalize-space(text())"/>
+            <xsl:text>",&#10;</xsl:text>
+            <xsl:text>                "@type": "PropertyValue",&#10;
+            "additionalType": ["geolink:Identifier",
+            "datacite:Identifier"],
+            "propertyID": "</xsl:text>
+            <xsl:value-of select="@alternateIdentifierType"/>
+            <xsl:text>",&#10;</xsl:text>
+            <xsl:text>      "value": "</xsl:text>
+            <xsl:value-of select="normalize-space(text())"/>
+            <xsl:text>"}</xsl:text>
+            <xsl:if
+                test="following-sibling::*[local-name() = 'alternateIdentifier' and not(starts-with(., 'http'))]">
+                <xsl:text>,&#10;</xsl:text>
+            </xsl:if>
+        </xsl:for-each>
+    </xsl:template>
+
+    <xsl:template name="keywords">
+        <xsl:for-each select="//*[local-name() = 'subject']">
+            <!-- extract one or more keywords from each keywordList element -->
+            <xsl:text>"</xsl:text>
+            <xsl:value-of select="text()"/>
+            <xsl:text>"</xsl:text>
+            <xsl:if test="following::*[local-name() = 'subject']">
+                <xsl:text>, </xsl:text>
+            </xsl:if>
+        </xsl:for-each>
+        <xsl:variable name="subjectsString">
+            <xsl:for-each select="//*[local-name() = 'subject']">
+                <xsl:value-of select="text()"/>
+            </xsl:for-each>
+        </xsl:variable>
+        <!--        <xsl:if
+            test="
+                count(//*[local-name() = 'subject']) > 0 and
+                count(//*[local-name() = 'geoLocationPlace']) > 0">
+            <xsl:text>, </xsl:text>
+        </xsl:if>-->
+        <xsl:for-each select="//*[local-name() = 'geoLocationPlace']">
+            <xsl:if test="not(contains($subjectsString, text()))">
+                <xsl:text>,&#10;"</xsl:text>
+                <xsl:value-of select="text()"/>
+                <xsl:text>"</xsl:text>
+                <!--              <xsl:if test="following::*[local-name() = 'geoLocationPlace']">
+                    <xsl:text>, </xsl:text>
+                </xsl:if>-->
+            </xsl:if>
+        </xsl:for-each>
+
+    </xsl:template>
+
+    <xsl:template match="//*[local-name() = 'fundingReferences']">
+        <!-- generates a list of JSON schem.org fundingReference key-value pairs -->
+
+        <xsl:for-each select="*[local-name() = 'fundingReference']">
+            <xsl:variable name="awardNumber">
+                <xsl:value-of select="*[local-name() = 'awardNumber']"/>
+            </xsl:variable>
+            <xsl:variable name="awardURI">
+                <xsl:value-of select="*[local-name() = 'awardNumber']/@awardURI"/>
+            </xsl:variable>
+            <xsl:variable name="awardName">
+                <xsl:value-of select="*[local-name() = 'awardTitle']"/>
+            </xsl:variable>
+            <xsl:variable name="funderName">
+                <xsl:value-of select="*[local-name() = 'funderName']"/>
+            </xsl:variable>
+            <xsl:variable name="funderID">
+                <xsl:if test="*[local-name() = 'funderIdentifier']">
+                    <xsl:if test="*[local-name() = 'funderIdentifier']/@funderIdentifierType">
+                        <xsl:value-of
+                            select="*[local-name() = 'funderIdentifier']/@funderIdentifierType"/>
+                        <xsl:text>:</xsl:text>
+                    </xsl:if>
+                    <xsl:value-of select="*[local-name() = 'funderIdentifier']"/>
+                </xsl:if>
+            </xsl:variable>
+
+
+            <xsl:text>{&#10;</xsl:text>
+            <xsl:if
+                test="
+                    string-length($awardURI) > 0 or
+                    string-length($awardNumber) > 0">
+                <xsl:text>     "@id":"</xsl:text>
+                <xsl:choose>
+                    <xsl:when test="string-length($awardURI) = 0">
+                        <xsl:value-of select="$awardNumber"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="$awardURI"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+                <xsl:text>",&#10;</xsl:text>
+            </xsl:if>
+
+            <xsl:text>     "@type": "CreativeWork",
+                "additionalType": "earthcollab:Project",&#10;</xsl:text>
+
+            <xsl:if test="string-length($awardName) > 0">
+                <xsl:text>     "name": "</xsl:text>
+                <xsl:value-of select="$awardName"/>
+                <xsl:text>",&#10;</xsl:text>
+            </xsl:if>
+            <xsl:if
+                test="
+                    string-length($funderName) > 0 or
+                    string-length($funderID) > 0">
+                <xsl:text>     "funder": {&#10;</xsl:text>
+                <xsl:text>       "@type":"Organization",&#10;</xsl:text>
+                <xsl:if test="string-length($funderName) > 0">
+                    <xsl:text>       "name":"</xsl:text>
+                    <xsl:value-of select="$funderName"/>
+                    <xsl:text>"</xsl:text>
+                    <xsl:if test="string-length($funderID) > 0">
+                        <xsl:text>,&#10;</xsl:text>
+                    </xsl:if>
+                </xsl:if>
+                <xsl:if test="string-length($funderID) > 0">
+                    <xsl:text>       "@id":"</xsl:text>
+                    <xsl:value-of select="$funderID"/>
+                    <xsl:text>"&#10;</xsl:text>
+                </xsl:if>
+                <xsl:text>       }&#10;</xsl:text>
+            </xsl:if>
+
+            <xsl:text>     }</xsl:text>
+            <xsl:if test="following-sibling::*[local-name() = 'fundingReference']">
+                <xsl:text>,&#10;</xsl:text>
+            </xsl:if>
+        </xsl:for-each>
+    </xsl:template>
+
+    <xsl:template name="spatialCoverage">
+        <!-- returns JSON array of schema.org geo objects 
+        polygons and boxes are @type GeoShape, points are @type GeoCoordinates-->
+        <xsl:text>[</xsl:text>
+        <xsl:for-each select="//*[local-name() = 'geoLocation']">
+            <!-- handle each geolocation element -->
+            <!-- place holder to put CRS into geolocation -->
+            <xsl:variable name="CRSvalue" select="''"/>
+
+            <!-- the DataCite XML v4 schema allows a geoLocation to have 0..1 Box, Polygon or Point, that
+    is... any combination of these -->
+            <xsl:variable name="geoShapeBox">
+                <xsl:if test="*[local-name() = 'geoLocationBox']">
+                    <xsl:value-of select="descendant::*[local-name() = 'westBoundLongitude']/text()"/>
+                    <xsl:text>, </xsl:text>
+                    <xsl:value-of select="descendant::*[local-name() = 'southBoundLatitude']/text()"/>
+                    <xsl:text> </xsl:text>
+                    <xsl:value-of select="descendant::*[local-name() = 'eastBoundLongitude']/text()"/>
+                    <xsl:text>, </xsl:text>
+                    <xsl:value-of select="descendant::*[local-name() = 'northBoundLatitude']/text()"
+                    />
+                </xsl:if>
+            </xsl:variable>
+            <xsl:variable name="geoShapePolygon">
+                <xsl:if test="*[local-name() = 'geoLocationPolygon']">
+                    <xsl:for-each
+                        select="*[local-name() = 'geoLocationPolygon']/*[local-name() = 'polygonPoint']">
+                        <xsl:value-of select="*[local-name() = 'pointLongitude']"/>
+                        <xsl:text>,</xsl:text>
+                        <xsl:value-of select="*[local-name() = 'pointLatitude']"/>
+                        <xsl:text>   </xsl:text>
+                    </xsl:for-each>
+                </xsl:if>
+            </xsl:variable>
+            <xsl:variable name="geoPoint">
+                <!-- schema.org geoShape does not include a point element -->
+                <xsl:if test="*[local-name() = 'geoLocationPoint']">
+                    <xsl:text>      "longitude":"</xsl:text>
+                    <xsl:value-of select="descendant::*[local-name() = 'pointLongitude']/text()"/>
+                    <xsl:text>",&#10;</xsl:text>
+                    <xsl:text>      "latitude":"</xsl:text>
+                    <xsl:value-of select="descendant::*[local-name() = 'pointLatitude']/text()"/>
+                    <xsl:text>"</xsl:text>
+                </xsl:if>
+            </xsl:variable>
+            <xsl:variable name="placeName" select="*[local-name() = 'geoLocationPlace']"/>
+
+            <xsl:text>{&#10;</xsl:text>
+            <xsl:text>"@type": "Place",&#10;</xsl:text>
+            <!-- if the Spatial referenc system is available... -->
+            <xsl:if test="$CRSvalue and string-length($CRSvalue) > 0">
+                <xsl:text>     "additionalProperty": [{
+            "@type": "PropertyValue",
+            "alternateName": "CRS",
+            "name": "Coordinate Reference System", &#10;</xsl:text>
+                <xsl:text>"value": "</xsl:text>
+                <xsl:value-of select="$CRSvalue"/>
+                <xsl:text>"&#10;}],&#10;</xsl:text>
+            </xsl:if>
+            <!-- if there's a place name  -->
+            <xsl:if test="$placeName and string-length($placeName) > 0">
+                <xsl:text>      "name": "</xsl:text>
+                <xsl:value-of select="$placeName"/>
+                <xsl:text>"</xsl:text>
+                <xsl:if
+                    test="
+                        string-length($geoShapePolygon) > 0 or
+                        string-length($geoShapeBox) > 0
+                        or string-length($geoPoint) > 0">
+                    <xsl:text>,&#10;</xsl:text>
+                </xsl:if>
+            </xsl:if>
+
+            <!-- if there are coordinates... -->
+            <xsl:if
+                test="
+                    string-length($geoShapePolygon) > 0 or string-length($geoShapeBox) > 0
+                    or string-length($geoPoint) > 0">
+                <xsl:text>      "geo":</xsl:text>
+                <xsl:if test="string-length($geoPoint) > 0">
+                    <!-- make geo an array, some @type GeoShape, and  
+                 @type GeoCoordinates-->
+                    <xsl:text>[</xsl:text>
+                </xsl:if>
+                <xsl:if
+                    test="string-length($geoShapePolygon) > 0 or string-length($geoShapeBox) > 0">
+                    <xsl:text>{&#10;</xsl:text>
+                    <xsl:text> 			"@type": "GeoShape",&#10;</xsl:text>
+                    <xsl:if test="string-length($geoShapeBox) > 0">
+                        <xsl:text> 			"box": "</xsl:text>
+                        <xsl:value-of select="$geoShapeBox"/>
+                        <xsl:text>"</xsl:text>
+                        <xsl:if test="string-length($geoShapePolygon) > 0">
+                            <xsl:text>,&#10;</xsl:text>
+                        </xsl:if>
+                    </xsl:if>
+
+                    <xsl:if test="string-length($geoShapePolygon) > 0">
+                        <xsl:text>      "polygon": "</xsl:text>
+                        <xsl:value-of select="$geoShapePolygon"/>
+                        <xsl:text>"</xsl:text>
+                    </xsl:if>
+                    <xsl:text>}</xsl:text>
+                    <xsl:if test="string-length($geoPoint) > 0">
+                        <xsl:text>,&#10;</xsl:text>
+                    </xsl:if>
+                </xsl:if>
+
+                <xsl:if test="string-length($geoPoint) > 0">
+                    <xsl:text>      {&#10;</xsl:text>
+                    <xsl:text> 			"@type": "GeoCoordinates",&#10;</xsl:text>
+                    <xsl:value-of select="$geoPoint"/>
+
+                    <!-- make geo an array, some @type GeoShape, and  
+                 @type GeoCoordinates-->
+                    <xsl:text>}]</xsl:text>
+                </xsl:if>
+            </xsl:if>
+            <!-- more content might be available; insert here -->
+
+            <xsl:text>}</xsl:text>
+            <xsl:if test="following::*[local-name() = 'geoLocation']">
+                <xsl:text>,&#10;</xsl:text>
+            </xsl:if>
+        </xsl:for-each>
+        <xsl:text>]</xsl:text>
+    </xsl:template>
+
+    <xsl:template name="spatialCoverage3">
+        <!-- V3 and 2 don't have a geoLocationPolygon, and represent coordinates as a list of doubles -->
+        <!-- returns JSON array of schema.org geo objects 
+        polygons and boxes are @type GeoShape, points are @type GeoCoordinates-->
+        <xsl:text>[</xsl:text>
+        <xsl:for-each select="//*[local-name() = 'geoLocation']">
+            <!-- handle each geolocation element -->
+            <!-- place holder to put CRS into geolocation -->
+            <xsl:variable name="CRSvalue" select="''"/>
+
+            <!-- the DataCite XML v3 schema allows a geoLocation to have 0..1 Box or Point, that
+    is... any combination of these.  Coordintate order is Lat long, e.g. point: -->
+            <xsl:variable name="geoShapeBox">
+
+                <xsl:if
+                    test="string-length(normalize-space(*[local-name() = 'geoLocationBox']/text())) > 0">
+                    <xsl:variable name="tokenizedList">
+                        <xsl:call-template name="tokenizeString">
+                            <xsl:with-param name="list"
+                                select="normalize-space(*[local-name() = 'geoLocationBox']/text())"/>
+                            <xsl:with-param name="delimiter" select="string(' ')"/>
+                        </xsl:call-template>
+                    </xsl:variable>
+                    <xsl:value-of select="$tokenizedList/token[2]/text()"/>
+                    <xsl:text>, </xsl:text>
+                    <xsl:value-of select="$tokenizedList/token[1]/text()"/>
+                    <xsl:text> </xsl:text>
+                    <xsl:value-of select="$tokenizedList/token[4]/text()"/>
+                    <xsl:text>, </xsl:text>
+                    <xsl:value-of select="$tokenizedList/token[3]/text()"/>
+
+                </xsl:if>
+            </xsl:variable>
+
+            <xsl:variable name="geoPoint">
+                <!-- schema.org geoShape does not include a point element -->
+                <!-- v3 example <geoLocationPoint> 31.233 ‐67.302 </geoLocationPoint> -->
+                <xsl:if test="*[local-name() = 'geoLocationPoint']">
+                    <xsl:text>      "longitude":"</xsl:text>
+                    <xsl:value-of
+                        select="substring-after(normalize-space(*[local-name() = 'geoLocationPoint']/text()), ' ')"/>
+                    <xsl:text>",&#10;</xsl:text>
+                    <xsl:text>      "latitude":"</xsl:text>
+                    <xsl:value-of
+                        select="substring-before(normalize-space(*[local-name() = 'geoLocationPoint']/text()), ' ')"/>
+                    <xsl:text>"</xsl:text>
+                </xsl:if>
+            </xsl:variable>
+            <xsl:variable name="placeName" select="*[local-name() = 'geoLocationPlace']"/>
+
+            <xsl:text>{&#10;</xsl:text>
+            <xsl:text>"@type": "Place",&#10;</xsl:text>
+            <!-- if the Spatial referenc system is available... -->
+            <xsl:if test="$CRSvalue and string-length($CRSvalue) > 0">
+                <xsl:text>     "additionalProperty": [{
+            "@type": "PropertyValue",
+            "alternateName": "CRS",
+            "name": "Coordinate Reference System", &#10;</xsl:text>
+                <xsl:text>"value": "</xsl:text>
+                <xsl:value-of select="$CRSvalue"/>
+                <xsl:text>"&#10;}],&#10;</xsl:text>
+            </xsl:if>
+            <!-- if there's a place name  -->
+            <xsl:if test="$placeName and string-length($placeName) > 0">
+                <xsl:text>      "name": "</xsl:text>
+                <xsl:value-of select="$placeName"/>
+                <xsl:text>"</xsl:text>
+                <xsl:if
+                    test="
+                        string-length($geoShapeBox) > 0
+                        or string-length($geoPoint) > 0">
+                    <xsl:text>,&#10;</xsl:text>
+                </xsl:if>
+            </xsl:if>
+
+            <!-- if there are coordinates... -->
+            <xsl:if
+                test="
+                    string-length($geoShapeBox) > 0
+                    or string-length($geoPoint) > 0">
+                <xsl:text>      "geo":</xsl:text>
+                <xsl:if test="string-length($geoPoint) > 0">
+                    <!-- make geo an array, some @type GeoShape, and  
+                 @type GeoCoordinates-->
+                    <xsl:text>[</xsl:text>
+                </xsl:if>
+                <xsl:if test="string-length($geoShapeBox) > 0">
+                    <xsl:text>{&#10;</xsl:text>
+                    <xsl:text> 			"@type": "GeoShape",&#10;</xsl:text>
+                    <xsl:if test="string-length($geoShapeBox) > 0">
+                        <xsl:text> 			"box": "</xsl:text>
+                        <xsl:value-of select="$geoShapeBox"/>
+                        <xsl:text>"</xsl:text>
+
+                    </xsl:if>
+
+
+                    <xsl:text>}</xsl:text>
+                    <xsl:if test="string-length($geoPoint) > 0">
+                        <xsl:text>,&#10;</xsl:text>
+                    </xsl:if>
+                </xsl:if>
+
+                <xsl:if test="string-length($geoPoint) > 0">
+                    <xsl:text>      {&#10;</xsl:text>
+                    <xsl:text> 			"@type": "GeoCoordinates",&#10;</xsl:text>
+                    <xsl:value-of select="$geoPoint"/>
+
+                    <!-- make geo an array, some @type GeoShape, and  
+                 @type GeoCoordinates-->
+                    <xsl:text>}]</xsl:text>
+                </xsl:if>
+            </xsl:if>
+            <!-- more content might be available; insert here -->
+
+            <xsl:text>}</xsl:text>
+            <xsl:if test="following::*[local-name() = 'geoLocation']">
+                <xsl:text>,&#10;</xsl:text>
+            </xsl:if>
+        </xsl:for-each>
+        <xsl:text>]</xsl:text>
+
+    </xsl:template>
+
+    <xsl:template name="variableMeasured">
+        <xsl:param name="variableList"/>
+        <!-- returns lsit of  of schema.org JSONld type PropertyValue objects
+        representing parameters or variables that are quantified in the dataset-->
+
+        <xsl:for-each select="$variableList/child::node()">
+            <!-- handle each variable node in the node list -->
+            <xsl:variable name="variableID" select="'variableID'"/>
+            <xsl:variable name="varDescription" select="'distFormat'"/>
+            <xsl:variable name="varUnitsText" select="'distPublishDate'"/>
+            <xsl:variable name="varURL" select="'distIdentifier'"/>
+            <xsl:variable name="varName" select="'distIdentifier'"/>
+            <xsl:variable name="varValue" select="'distIdentifier'"/>
+
+            <xsl:text>{&#10;</xsl:text>
+
+            <xsl:if test="$variableID">
+                <xsl:text>      "@id": "</xsl:text>
+                <xsl:value-of select="$variableID"/>
+                <xsl:text>",&#10;</xsl:text>
+            </xsl:if>
+
+            <xsl:text>    "@type": "PropertyValue",&#10;    "additionalType": "earthcollab:Parameter",&#10;</xsl:text>
+
+            <xsl:if test="$varDescription">
+                <xsl:text>      "description": "</xsl:text>
+                <xsl:value-of select="$varDescription"/>
+                <xsl:text>",&#10;</xsl:text>
+            </xsl:if>
+
+            <xsl:text>      "unitText": "</xsl:text>
+            <xsl:value-of select="$varUnitsText"/>
+            <xsl:text>",&#10;</xsl:text>
+
+            <xsl:if test="$varURL">
+                <xsl:text>      "url": "</xsl:text>
+                <xsl:value-of select="$varURL"/>
+                <xsl:text>",&#10;</xsl:text>
+            </xsl:if>
+
+            <xsl:if test="$varValue">
+                <xsl:text>      "value": "</xsl:text>
+                <xsl:value-of select="$varValue"/>
+                <xsl:text>"&#10;</xsl:text>
+            </xsl:if>
+
+            <!-- more content might be available; insert here -->
+
+            <xsl:text>}</xsl:text>
+            <!-- update logic here to determine if need comma -->
+            <xsl:if test="following-sibling::*[local-name() = 'title']">
+                <xsl:text>,&#10;</xsl:text>
+            </xsl:if>
+
+        </xsl:for-each>
+    </xsl:template>
+
+    <!--############################################################-->
+    <!--## Template to tokenize strings                           ##-->
+    <!--############################################################-->
+    <!-- template adopted from https://heber.it/blog/2012/08/tokenize-string-in-xslt-1-0/ -->
+    <xsl:template name="tokenizeString">
+        <!--passed template parameter -->
+        <xsl:param name="list"/>
+        <xsl:param name="delimiter"/>
+        <xsl:choose>
+            <xsl:when test="contains($list, $delimiter)">
+                <token>
+                    <!-- get everything in front of the first delimiter -->
+                    <xsl:value-of select="substring-before($list, $delimiter)"/>
+                </token>
+                <xsl:call-template name="tokenizeString">
+                    <!-- store anything left in another variable -->
+                    <xsl:with-param name="list" select="substring-after($list, $delimiter)"/>
+                    <xsl:with-param name="delimiter" select="$delimiter"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:choose>
+                    <xsl:when test="$list = ''">
+                        <xsl:text/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <token>
+                            <xsl:value-of select="$list"/>
+                        </token>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!--############################################################-->
+    <!--## Template to replace strings                           ##-->
+    <!--############################################################-->
+    <!-- template from https://stackoverflow.com/questions/3067113/xslt-string-replace/3067130 -->
+    <xsl:template name="string-replace-all">
+        <xsl:param name="text"/>
+        <xsl:param name="replace"/>
+        <xsl:param name="by"/>
+        <xsl:choose>
+            <xsl:when test="$text = '' or $replace = '' or not($replace)">
+                <!-- Prevent this routine from hanging -->
+                <xsl:value-of select="$text"/>
+            </xsl:when>
+            <xsl:when test="contains($text, $replace)">
+                <xsl:value-of select="substring-before($text, $replace)"/>
+                <xsl:value-of select="$by"/>
+                <xsl:call-template name="string-replace-all">
+                    <xsl:with-param name="text" select="substring-after($text, $replace)"/>
+                    <xsl:with-param name="replace" select="$replace"/>
+                    <xsl:with-param name="by" select="$by"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$text"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+
+    <xsl:template match="//*[local-name() = 'resource']">
+        <!-- Define variables for content elements -->
+        <xsl:variable name="additionalContexts">
+            <xsl:text>"datacite": "http://purl.org/spar/datacite/",
+                "earthcollab": "https://library.ucar.edu/earthcollab/schema#",
+                "geolink": "http://schema.geolink.org/1.0/base/main#",
+                "vivo": "http://vivoweb.org/ontology/core#",
+                "dcat":"http://www.w3.org/ns/dcat#"
+                </xsl:text>
+        </xsl:variable>
+        <xsl:variable name="DOIuri"> DOI:<xsl:value-of select="//*[local-name() = 'identifier']"/>
+        </xsl:variable>
+        <xsl:variable name="DOIvalue">
+            <xsl:value-of select="//*[local-name() = 'identifier']"/>
+        </xsl:variable>
+        <xsl:variable name="name">
+            <xsl:value-of select="//*[local-name() = 'title' and not(@titleType)][1]"/>
+        </xsl:variable>
+        <xsl:variable name="alternateName">
+            <xsl:choose>
+                <xsl:when test="count(//*[local-name() = 'title' and @titleType]) = 1">
+                    <xsl:text>"</xsl:text>
+                    <!-- clean up any double quotes in the text -->
+                    <xsl:call-template name="string-replace-all">
+                        <xsl:with-param name="text"
+                            select="//*[local-name() = 'title' and @titleType]"/>
+                        <xsl:with-param name="replace" select="string('&#34;')"/>
+                        <xsl:with-param name="by" select="string('\&#34;')"/>
+                    </xsl:call-template>
+                    <xsl:text>"</xsl:text>
+                </xsl:when>
+                <xsl:when test="count(//*[local-name() = 'title' and @titleType]) > 1">
+                    <xsl:text>[</xsl:text>
+                    <xsl:for-each select="//*[local-name() = 'title' and @titleType]">
+                        <xsl:text>"</xsl:text>
+                        <!-- clean up any double quotes in the text -->
+                        <xsl:call-template name="string-replace-all">
+                            <xsl:with-param name="text" select="normalize-space(text())"/>
+                            <xsl:with-param name="replace" select="string('&#34;')"/>
+                            <xsl:with-param name="by" select="string('\&#34;')"/>
+                        </xsl:call-template>
+                        <xsl:text>"</xsl:text>
+                        <xsl:if test="following-sibling::*[local-name() = 'title']">
+                            <xsl:text>,&#10;</xsl:text>
+                        </xsl:if>
+                    </xsl:for-each>
+                    <xsl:text>]</xsl:text>
+                </xsl:when>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:variable name="citation">
+            <xsl:for-each select="//*[local-name() = 'creatorName']">
+                <xsl:value-of select="normalize-space(text())"/>
+                <xsl:if test="following::*[local-name() = 'creator']">
+                    <xsl:text>, </xsl:text>
+                </xsl:if>
+            </xsl:for-each>
+            <xsl:text> (</xsl:text>
+            <xsl:value-of select="//*[local-name() = 'publicationYear']"/>
+            <xsl:text>), </xsl:text>
+            <!-- will potentially have problems here if there are multiple titles; this just takes the first one -->
+            <xsl:value-of disable-output-escaping="yes" select="//*[local-name() = 'title'][1]"/>
+            <xsl:text>. </xsl:text>
+            <xsl:value-of disable-output-escaping="yes"
+                select="normalize-space(string(//*[local-name() = 'publisher']))"/>
+            <xsl:text>. doi:</xsl:text>
+            <xsl:value-of select="//*[local-name() = 'identifier']"/>
+
+        </xsl:variable>
+        <xsl:variable name="datePublished" select="//*[local-name() = 'publicationYear']"/>
+        <xsl:variable name="description">
+            <xsl:for-each select="//*[local-name() = 'description']">
+                <xsl:choose>
+                    <xsl:when test="@descriptionType = 'Abstract'">
+                        <xsl:value-of select="concat('Abstract: ', string(.))"/>
+                    </xsl:when>
+                    <xsl:when test="@descriptionType = 'SeriesInformation'">
+                        <xsl:value-of select="concat('Series Information: ', string(.))"/>
+                    </xsl:when>
+                    <xsl:when test="@descriptionType = 'TableOfContents'">
+                        <xsl:value-of select="concat('Table of Contents: ', string(.))"/>
+                    </xsl:when>
+                    <xsl:when test="@descriptionType = 'TechnicalInfo'">
+                        <xsl:value-of select="concat('Techical Information: ', string(.))"/>
+                    </xsl:when>
+                    <xsl:when test="@descriptionType = 'Other'">
+                        <xsl:value-of select="concat('Other Description: ', string(.))"/>
+                    </xsl:when>
+                </xsl:choose>
+                <xsl:if test="following-sibling::*[local-name() = 'description']">
+                    <xsl:text>;       </xsl:text>
+                </xsl:if>
+            </xsl:for-each>
+        </xsl:variable>
+        <xsl:variable name="DataCatalogName" select="''"/>
+        <xsl:variable name="DataCatalogURL" select="''"/>
+        <xsl:variable name="license">
+            <xsl:choose>
+                <xsl:when test="count(//*[local-name() = 'rights']) = 1">
+                    <xsl:text>"</xsl:text>
+                    <xsl:value-of select="//*[local-name() = 'rights']"/>
+                    <xsl:text>"</xsl:text>
+                </xsl:when>
+                <xsl:when test="count(//*[local-name() = 'rights']) > 1">
+                    <xsl:for-each select="//*[local-name() = 'rights']">
+                        <xsl:text>"</xsl:text>
+                        <xsl:value-of select="text()"/>
+                        <xsl:text>"</xsl:text>
+                        <xsl:if test="following-sibling::*[local-name() = 'rights']">
+                            <xsl:text>,&#10;</xsl:text>
+                        </xsl:if>
+                    </xsl:for-each>
+                </xsl:when>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:variable name="dateCreated" select="//*[local-name() = 'date' and @dateType='Created']"/>
+        <xsl:variable name="dateModified" select="//*[local-name() = 'date' and @dateType='Updated']"/>
+        <xsl:variable name="version" select="//*[local-name() = 'version']"/>
+        <xsl:variable name="language" select="//*[local-name() = 'language']"/>
+        
+        <!-- default values to use in lieu of extracted provider; customize
+      logic in format/profile-specific implementations to decide which to use-->
+        <xsl:variable name="providerDefault">
+            <xsl:text>
+		"@type": "Organization",
+		"@id": "https://www.iedadata.org/",
+		"name": "Interdisciplinary Earth Data Alliance (IEDA)"
+            </xsl:text>
+        </xsl:variable>
+        <xsl:variable name="publisherDefault">
+            <xsl:text>
+		"@type": "Organization",
+		"@id": "https://www.iedadata.org/",
+		"name": "Interdisciplinary Earth Data Alliance (IEDA)",
+		"url": "https://www.iedadata.org/",
+		"description": "The IEDA data facility mission is to support, sustain, and advance the geosciences by providing data services for observational geoscience data from the Ocean, Earth, and Polar Sciences. IEDA systems serve as primary community data collections for global geochemistry and marine geoscience research and support the preservation, discovery, retrieval, and analysis of a wide range of observational field and analytical data types. Our tools and services are designed to facilitate data discovery and reuse for focused disciplinary research and to support interdisciplinary research and data integration.",
+		"logo": {
+			"@type": "ImageObject",
+			"url": ""
+		},
+		"contactPoint": {
+			"@type": "ContactPoint",
+			"name": "Kerstin Lehnert",
+			"email": "lehnert@ldeo.columbia.edu",
+			"url": "http://orcid.org/0000-0001-7036-1977",
+			"contactType": "Director"
+		},
+		"parentOrganization": {
+			"@type": "Organization",
+			"@id": "https://viaf.org/viaf/142992181/",
+			"name": "Lamont-Doherty Earth Observatory",
+			"url": "http://www.ldeo.columbia.edu/",
+			"address": {
+				"@type": "PostalAddress",
+				"streetAddress": "61 Route 9W",
+				"addressLocality": "Palisades",
+				"addressRegion": "NY",
+				"postalCode": "10964-1000",
+				"addressCountry": "USA"
+			},
+			"parentOrganization": {
+				"@type": "Organization",
+				"@id": "https://viaf.org/viaf/156836332/",
+				"legalName": "Columbia University",
+				"url": "http://www.columbia.edu/"
+			} 
+            }
+        </xsl:text>
+        </xsl:variable>
+        <xsl:variable name="publshingPrinciplesDefault">
+            <xsl:text>
+			"@id": "http://creativecommons.org/licenses/by-nc-sa/3.0/us/",
+			"@type": "DigitalDocument",
+			"additionalType": "gdx:Protocol-License",
+			"name": "Dataset Usage License",
+			"description": "Creative Commons Attribution-NonCommercial-Share Alike 3.0 United States [CC BY-NC-SA 3.0]",
+			"url": "https://creativecommons.org/licenses/by-nc-sa/3.0/us/"
+            </xsl:text>
+        </xsl:variable>
+        <xsl:variable name="publisherFunderDefault">
+            <xsl:text>
+          {
+            "@type": "Organization",
+            "@id": "http://dx.doi.org/10.13039/100000085",
+            "legalName": "Directorate for Geosciences",
+            "alternateName": "NSF-GEO",
+            "url": "http://www.nsf.gov",
+            "parentOrganization": {
+                "@type": "Organization",
+                "@id": "http://dx.doi.org/10.13039/100000001",
+                "legalName": "National Science Foundation",
+                "alternateName": "NSF",
+                "url": "http://www.nsf.gov"
+            }
+           }
+            </xsl:text>
+        </xsl:variable>
+        <xsl:variable name="provider" select="//*[local-name() = 'publisher']"/>
+        <xsl:variable name="publisher" select="//*[local-name() = 'publisher']"/>
+        <xsl:variable name="publishingPrinciples" select="''"/>
+        <xsl:variable name="hasSpatial" select="count(//*[local-name() = 'geoLocation']) > 0"/>
+        <xsl:variable name="hasVariables" select="false()"/>
+
+<!-- ******************************************************************************************* -->
+        <!-- construct the JSON with xsl text elements. &#10; is carriage return -->
+        <xsl:text>{&#10;  "@context": {&#10;</xsl:text>
+        <xsl:text> "@vocab": "http://schema.org/"</xsl:text>
+        <xsl:if test="$additionalContexts and string-length($additionalContexts) > 0">
+            <xsl:text>, &#10;</xsl:text>
+            <xsl:value-of select="$additionalContexts"/>
+        </xsl:if>
+        <xsl:text>  },&#10; </xsl:text>
+
+        <xsl:text>"@id": "</xsl:text>
+        <xsl:value-of select="$DOIuri"/>
+        <xsl:text>",&#10;</xsl:text>
+        <xsl:text>  "@type": "Dataset",&#10;</xsl:text>
+        <xsl:text>  "additionalType": [&#10;    "geolink:Dataset",&#10;    "vivo:Dataset"&#10;  ],&#10;</xsl:text>
+
+        <xsl:text>  "name": "</xsl:text>
+        <!-- clean up any double quotes in the text -->
+        <xsl:call-template name="string-replace-all">
+            <xsl:with-param name="text" select="$name"/>
+            <xsl:with-param name="replace" select="string('&#34;')"/>
+            <xsl:with-param name="by" select="string('\&#34;')"/>
+        </xsl:call-template>
+        <xsl:text>",&#10;</xsl:text>
+
+        <xsl:if test="$alternateName and string-length($alternateName) > 0">
+            <xsl:text>  "alternateName": </xsl:text>
+            <!-- alternate name might be single or array; the variable assignment puts quotes in -->
+
+            <xsl:value-of select="$alternateName"/>
+            <xsl:text>,&#10;</xsl:text>
+        </xsl:if>
+
+        <xsl:text>  "citation": "</xsl:text>
+        <!-- clean up any double quotes in the text -->
+        <xsl:call-template name="string-replace-all">
+            <xsl:with-param name="text" select="$citation"/>
+            <xsl:with-param name="replace" select="string('&#34;')"/>
+            <xsl:with-param name="by" select="string('\&#34;')"/>
+        </xsl:call-template>
+        <xsl:text>",&#10;</xsl:text>
+
+        <xsl:text>  "creator":</xsl:text>
+        <xsl:apply-templates select="//*[local-name() = 'creators']"/>
+        <xsl:text>,&#10;</xsl:text>
+
+        <xsl:text>  "datePublished": "</xsl:text>
+        <xsl:value-of select="$datePublished"/>
+        <xsl:text>",&#10;</xsl:text>
+          
+        <xsl:if test="string-length($dateCreated)>0">
+            <xsl:text>  "dateCreated": "</xsl:text>
+            <xsl:value-of select="$dateCreated"/>
+            <xsl:text>",&#10;</xsl:text>
+        </xsl:if>
+        
+        <xsl:if test="string-length($dateModified)>0">
+            <xsl:text>  "dateModified": "</xsl:text>
+            <xsl:value-of select="$dateModified"/>
+            <xsl:text>",&#10;</xsl:text>
+        </xsl:if>
+        
+        <xsl:if test="string-length($version)>0">
+            <xsl:text>  "version": "</xsl:text>
+            <xsl:value-of select="$version"/>
+            <xsl:text>",&#10;</xsl:text>
+        </xsl:if>
+        
+        <xsl:if test="string-length($language)>0">
+            <xsl:text>  "inLanguage": "</xsl:text>
+            <xsl:value-of select="$language"/>
+            <xsl:text>",&#10;</xsl:text>
+        </xsl:if>
+        
+        <xsl:text>  "description": "</xsl:text>
+        <!-- clean up any double quotes in the text -->
+        <xsl:call-template name="string-replace-all">
+            <xsl:with-param name="text" select="normalize-space($description)"/>
+            <xsl:with-param name="replace" select="string('&#34;')"/>
+            <xsl:with-param name="by" select="string('\&#34;')"/>
+        </xsl:call-template>
+        <xsl:text>",&#10;</xsl:text>
+
+        <xsl:text>  "distribution": [&#10;</xsl:text>
+        <!-- template should return a list of JSON objects of type
+            schema.org DataDownload. -->
+        <xsl:call-template name="distributions"/>
+        <xsl:text>  ],&#10;</xsl:text>
+
+        <xsl:text>  "identifier": [</xsl:text>
+        <xsl:call-template name="identifiers"/>
+        <xsl:text>  ],&#10;</xsl:text>
+
+        <xsl:if test="$DataCatalogName or $DataCatalogURL">
+            <xsl:text>  "includedInDataCatalog": {&#10; 
+    "@type":"DataCatalog",&#10;</xsl:text>
+            <xsl:if test="$DataCatalogName">
+                <xsl:text>  "name":"</xsl:text>
+                <xsl:value-of select="$DataCatalogName"/>
+                <xsl:text>",&#10;</xsl:text>
+            </xsl:if>
+            <xsl:if test="$DataCatalogURL">
+                <xsl:text>  "url": "</xsl:text>
+                <xsl:value-of select="$DataCatalogURL"/>
+                <xsl:text>"&#10;</xsl:text>
+            </xsl:if>
+            <xsl:text>},&#10;</xsl:text>
+
+        </xsl:if>
+        <!-- put award information in isPartOf...  -->
+
+        <xsl:if test="//*[local-name() = 'fundingReferences']">
+            <xsl:text>  "isPartOf": [</xsl:text>
+            <xsl:apply-templates select="//*[local-name() = 'fundingReferences']"/>
+            <xsl:text>],&#10;</xsl:text>
+        </xsl:if>
+
+        <xsl:if test="//*[local-name() = 'subjects']">
+            <xsl:text>  "keywords": [</xsl:text>
+            <xsl:call-template name="keywords"/>
+            <xsl:text>],&#10;</xsl:text>
+        </xsl:if>
+
+        <xsl:if test="string-length($license) > 0">
+            <xsl:text>  "license": </xsl:text>
+            <xsl:value-of select="$license"/>
+            <xsl:text>,&#10;</xsl:text>
+        </xsl:if>
+
+        <!--  "measurementTechnique": ["Electron Microprobe"], aspiration...-->
+
+        <xsl:text>  "provider": &#10;</xsl:text>
+        <xsl:choose>
+            <xsl:when test="not(contains($provider, 'IEDA'))">
+                <xsl:text>        {"@type": "Organization",
+                   "name":"</xsl:text>
+                <xsl:value-of select="$provider"/>
+                <xsl:text>"},</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>           {</xsl:text>
+                <xsl:value-of select="$providerDefault"/>
+                <xsl:text>},&#10;</xsl:text>
+            </xsl:otherwise>
+
+        </xsl:choose>
+
+        <xsl:text>  "publisher": {&#10;</xsl:text>
+        <xsl:choose>
+            <xsl:when test="contains($publisher, 'IEDA')">
+                <xsl:value-of select="$publisherDefault"/>
+
+                <xsl:if test="string-length($publisherFunderDefault) > 0">
+                    <xsl:text>,&#10;            "funder": </xsl:text>
+                    <xsl:value-of select="$publisherFunderDefault"/>
+
+                </xsl:if>
+                <xsl:if test="string-length($publshingPrinciplesDefault) > 0">
+                    <xsl:text>,&#10;            "publishingPrinciples": {&#10;</xsl:text>
+                    <xsl:value-of select="$publshingPrinciplesDefault"/>
+                </xsl:if>
+                <xsl:text>&#10;       }
+                }</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>        "@type": "Organization",
+                   "name":"</xsl:text>
+                <xsl:value-of select="$publisher"/>
+                <xsl:text>"</xsl:text>
+
+                <xsl:if test="string-length($publishingPrinciples) > 0">
+                    <xsl:text>,
+            "publishingPrinciples": {&#10;</xsl:text>
+                    <xsl:value-of select="$publishingPrinciples"/>
+                    <xsl:text>&#10;       }</xsl:text>
+                </xsl:if>
+                <!-- close the publisher element -->
+                <xsl:text>&#10;    }</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+
+        <xsl:if test="$hasSpatial or $hasVariables">
+            <xsl:text>,&#10;</xsl:text>
+        </xsl:if>
+
+        <xsl:if test="$hasSpatial">
+            <xsl:text>  "spatialCoverage": </xsl:text>
+            <!-- templates return a list of JSON objects -->
+            <xsl:choose>
+                <xsl:when
+                    test="string(namespace-uri(//*[local-name() = 'identifier'])) = 'http://datacite.org/schema/kernel-4'">
+                    <xsl:call-template name="spatialCoverage"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:call-template name="spatialCoverage3"/>
+                </xsl:otherwise>
+            </xsl:choose>
+            <!--        <xsl:text>]</xsl:text>-->
+            <xsl:if test="$hasVariables">
+                <xsl:text>,&#10;</xsl:text>
+            </xsl:if>
+        </xsl:if>
+
+
+        <xsl:if test="$hasVariables">
+            <xsl:text>  "variableMeasured": [</xsl:text>
+            <xsl:call-template name="variableMeasured">
+                <xsl:with-param name="variableList"> </xsl:with-param>
+            </xsl:call-template>
+            <xsl:text>]</xsl:text>
+        </xsl:if>
+        <xsl:text>}</xsl:text>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/DataCite2SDO/ExampleOutput/DataCite-10.1594_ieda_100577xx.json
+++ b/DataCite2SDO/ExampleOutput/DataCite-10.1594_ieda_100577xx.json
@@ -1,0 +1,130 @@
+{
+    "@context": {
+        "@vocab": "http://schema.org/",
+        "datacite": "http://purl.org/spar/datacite/",
+        "earthcollab": "https://library.ucar.edu/earthcollab/schema#",
+        "geolink": "http://schema.geolink.org/1.0/base/main#",
+        "vivo": "http://vivoweb.org/ontology/core#",
+        "dcat": "http://www.w3.org/ns/dcat#"
+    },
+    "@id": " DOI:10.1594/IEDA/100577",
+    "@type": "Dataset",
+    "additionalType": [
+        "geolink:Dataset",
+        "vivo:Dataset"
+    ],
+    "name": "Elemental OC, N and Stable C Isotopes for IODP Expedition 341 (Southern Alaska Margin)",
+    "citation": "Blair, Neal E., Childress, Laurel B. (2016), Elemental OC, N and Stable C Isotopes for IODP Expedition 341 (Southern Alaska Margin). Integrated Earth Data Applications (IEDA). doi:10.1594/IEDA/100577",
+    "creator": [
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Blair, Neal E."
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Childress, Laurel B."
+        }
+    ],
+    "datePublished": "2016",
+    "description": "",
+    "distribution": [{
+        "@type": "DataDownload",
+        "additionalType": "dcat:distribution",
+        "name": "DOI landing page",
+        "dcat:accessURL": "http://dx.doi.org/10.1594/IEDA/100577",
+        "url": "http://dx.doi.org/10.1594/IEDA/100577",
+        "encodingFormat": "application/vnd.ms-excel"
+    }],
+    "identifier": [
+        {
+            "@id": " doi:10.1594/IEDA/100577",
+            "@type": "PropertyValue",
+            "additionalType": [
+                "geolink:Identifier",
+                "datacite:Identifier"
+            ],
+            "propertyID": "datacite:doi",
+            "url": "http://dx.doi.org/10.1594/IEDA/100577",
+            "value": "10.1594/IEDA/100577"
+        },
+        {
+            "@id": "917",
+            "@type": "PropertyValue",
+            "additionalType": [
+                "geolink:Identifier",
+                "datacite:Identifier"
+            ],
+            "propertyID": "ECL",
+            "value": "917"
+        }
+    ],
+    "keywords": ["Chemistry:Sediment"],
+    "license": "Creative Commons Attribution-NonCommercial-Share Alike 3.0 United States [CC BY-NC-SA 3.0]",
+    "provider": {
+        "@type": "Organization",
+        "@id": "https://www.iedadata.org/",
+        "name": "Interdisciplinary Earth Data Alliance (IEDA)"
+    },
+    "publisher": {
+        "@type": "Organization",
+        "@id": "https://www.iedadata.org/",
+        "name": "Interdisciplinary Earth Data Alliance (IEDA)",
+        "url": "https://www.iedadata.org/",
+        "description": "The IEDA data facility mission is to support, sustain, and advance the geosciences by providing data services for observational geoscience data from the Ocean, Earth, and Polar Sciences. IEDA systems serve as primary community data collections for global geochemistry and marine geoscience research and support the preservation, discovery, retrieval, and analysis of a wide range of observational field and analytical data types. Our tools and services are designed to facilitate data discovery and reuse for focused disciplinary research and to support interdisciplinary research and data integration.",
+        "logo": {
+            "@type": "ImageObject",
+            "url": ""
+        },
+        "contactPoint": {
+            "@type": "ContactPoint",
+            "name": "Kerstin Lehnert",
+            "email": "lehnert@ldeo.columbia.edu",
+            "url": "http://orcid.org/0000-0001-7036-1977",
+            "contactType": "Director"
+        },
+        "parentOrganization": {
+            "@type": "Organization",
+            "@id": "https://viaf.org/viaf/142992181/",
+            "name": "Lamont-Doherty Earth Observatory",
+            "url": "http://www.ldeo.columbia.edu/",
+            "address": {
+                "@type": "PostalAddress",
+                "streetAddress": "61 Route 9W",
+                "addressLocality": "Palisades",
+                "addressRegion": "NY",
+                "postalCode": "10964-1000",
+                "addressCountry": "USA"
+            },
+            "parentOrganization": {
+                "@type": "Organization",
+                "@id": "https://viaf.org/viaf/156836332/",
+                "legalName": "Columbia University",
+                "url": "http://www.columbia.edu/"
+            }
+        },
+        "funder": {
+            "@type": "Organization",
+            "@id": "http://dx.doi.org/10.13039/100000085",
+            "legalName": "Directorate for Geosciences",
+            "alternateName": "NSF-GEO",
+            "url": "http://www.nsf.gov",
+            "parentOrganization": {
+                "@type": "Organization",
+                "@id": "http://dx.doi.org/10.13039/100000001",
+                "legalName": "National Science Foundation",
+                "alternateName": "NSF",
+                "url": "http://www.nsf.gov"
+            }
+        },
+        "publishingPrinciples": {
+            "@id": "http://creativecommons.org/licenses/by-nc-sa/3.0/us/",
+            "@type": "DigitalDocument",
+            "additionalType": "gdx:Protocol-License",
+            "name": "Dataset Usage License",
+            "description": "Creative Commons Attribution-NonCommercial-Share Alike 3.0 United States [CC BY-NC-SA 3.0]",
+            "url": "https://creativecommons.org/licenses/by-nc-sa/3.0/us/"
+        }
+    }
+}

--- a/DataCite2SDO/ExampleOutput/DataCite-10.1594_ieda_324306xx.json
+++ b/DataCite2SDO/ExampleOutput/DataCite-10.1594_ieda_324306xx.json
@@ -1,0 +1,133 @@
+{
+    "@context": {
+        "@vocab": "http://schema.org/",
+        "datacite": "http://purl.org/spar/datacite/",
+        "earthcollab": "https://library.ucar.edu/earthcollab/schema#",
+        "geolink": "http://schema.geolink.org/1.0/base/main#",
+        "vivo": "http://vivoweb.org/ontology/core#",
+        "dcat": "http://www.w3.org/ns/dcat#"
+    },
+    "@id": " DOI:10.1594/IEDA/324306",
+    "@type": "Dataset",
+    "additionalType": [
+        "geolink:Dataset",
+        "vivo:Dataset"
+    ],
+    "name": "Processed EM302 Swath Bathymetry and Acoustic Backscatter Data from the Lau Back-arc Basin acquired during R/V Falkor expedition FK160407 (2016)",
+    "citation": "Ferrini, Vicki (2017), Processed EM302 Swath Bathymetry and Acoustic Backscatter Data from the Lau Back-arc Basin acquired during R/V Falkor expedition FK160407 (2016). Integrated Earth Data Applications (IEDA). doi:10.1594/IEDA/324306",
+    "creator": [{
+        "@type": "Person",
+        "additionalType": "geolink:Person",
+        "name": "Ferrini, Vicki"
+    }],
+    "datePublished": "2017",
+    "description": "Abstract: This data set was acquired with a Kongsberg Maritime EM302 Multibeam Sonar during R/V Falkor expedition FK160407 conducted in 2016 (Chief Scientist: Dr. Charles Fisher, Investigator: Dr. Vicki Ferrini). These data files are of MBSystem-compatible format and include Acoustic Backscatter and Swath Bathymetry data that were processed after acquisition. Data were acquired as part of the project: Collaborative Research: Ecosystem dynamics of Western Pacific hydrothermal vent communities associated with polymetallic sulfide deposits. Ship time was provided by Schmidt Ocean Institute and additional funding was provided by NSF Award(s): OCE15-36331, OCE15-36650, OCE15-36653, OCE15-37807.",
+    "distribution": [{
+        "@type": "DataDownload",
+        "additionalType": "dcat:distribution",
+        "name": "DOI landing page",
+        "dcat:accessURL": "http://dx.doi.org/10.1594/IEDA/324306",
+        "url": "http://dx.doi.org/10.1594/IEDA/324306",
+        "encodingFormat": "application/octet-stream"
+    }],
+    "identifier": [
+        {
+            "@id": " doi:10.1594/IEDA/324306",
+            "@type": "PropertyValue",
+            "additionalType": [
+                "geolink:Identifier",
+                "datacite:Identifier"
+            ],
+            "propertyID": "datacite:doi",
+            "url": "http://dx.doi.org/10.1594/IEDA/324306",
+            "value": "10.1594/IEDA/324306"
+        },
+        {
+            "@id": "24306",
+            "@type": "PropertyValue",
+            "additionalType": [
+                "geolink:Identifier",
+                "datacite:Identifier"
+            ],
+            "propertyID": "MGDS",
+            "value": "24306"
+        }
+    ],
+    "keywords": [
+        "Backscatter:Acoustic",
+        "Bathymetry:Swath"
+    ],
+    "license": "Creative Commons Attribution-NonCommercial-Share Alike 3.0 United States [CC BY-NC-SA 3.0]",
+    "provider": {
+        "@type": "Organization",
+        "@id": "https://www.iedadata.org/",
+        "name": "Interdisciplinary Earth Data Alliance (IEDA)"
+    },
+    "publisher": {
+        "@type": "Organization",
+        "@id": "https://www.iedadata.org/",
+        "name": "Interdisciplinary Earth Data Alliance (IEDA)",
+        "url": "https://www.iedadata.org/",
+        "description": "The IEDA data facility mission is to support, sustain, and advance the geosciences by providing data services for observational geoscience data from the Ocean, Earth, and Polar Sciences. IEDA systems serve as primary community data collections for global geochemistry and marine geoscience research and support the preservation, discovery, retrieval, and analysis of a wide range of observational field and analytical data types. Our tools and services are designed to facilitate data discovery and reuse for focused disciplinary research and to support interdisciplinary research and data integration.",
+        "logo": {
+            "@type": "ImageObject",
+            "url": ""
+        },
+        "contactPoint": {
+            "@type": "ContactPoint",
+            "name": "Kerstin Lehnert",
+            "email": "lehnert@ldeo.columbia.edu",
+            "url": "http://orcid.org/0000-0001-7036-1977",
+            "contactType": "Director"
+        },
+        "parentOrganization": {
+            "@type": "Organization",
+            "@id": "https://viaf.org/viaf/142992181/",
+            "name": "Lamont-Doherty Earth Observatory",
+            "url": "http://www.ldeo.columbia.edu/",
+            "address": {
+                "@type": "PostalAddress",
+                "streetAddress": "61 Route 9W",
+                "addressLocality": "Palisades",
+                "addressRegion": "NY",
+                "postalCode": "10964-1000",
+                "addressCountry": "USA"
+            },
+            "parentOrganization": {
+                "@type": "Organization",
+                "@id": "https://viaf.org/viaf/156836332/",
+                "legalName": "Columbia University",
+                "url": "http://www.columbia.edu/"
+            }
+        },
+        "funder": {
+            "@type": "Organization",
+            "@id": "http://dx.doi.org/10.13039/100000085",
+            "legalName": "Directorate for Geosciences",
+            "alternateName": "NSF-GEO",
+            "url": "http://www.nsf.gov",
+            "parentOrganization": {
+                "@type": "Organization",
+                "@id": "http://dx.doi.org/10.13039/100000001",
+                "legalName": "National Science Foundation",
+                "alternateName": "NSF",
+                "url": "http://www.nsf.gov"
+            }
+        },
+        "publishingPrinciples": {
+            "@id": "http://creativecommons.org/licenses/by-nc-sa/3.0/us/",
+            "@type": "DigitalDocument",
+            "additionalType": "gdx:Protocol-License",
+            "name": "Dataset Usage License",
+            "description": "Creative Commons Attribution-NonCommercial-Share Alike 3.0 United States [CC BY-NC-SA 3.0]",
+            "url": "https://creativecommons.org/licenses/by-nc-sa/3.0/us/"
+        }
+    },
+    "spatialCoverage": [{
+        "@type": "Place",
+        "geo": {
+            "@type": "GeoShape",
+            "box": "-176.742902, -22.400739 -174.908822, -20.040408"
+        }
+    }]
+}

--- a/DataCite2SDO/ExampleOutput/DataCite-10.1594_ieda_324328xx.json
+++ b/DataCite2SDO/ExampleOutput/DataCite-10.1594_ieda_324328xx.json
@@ -1,0 +1,145 @@
+{
+    "@context": {
+        "@vocab": "http://schema.org/",
+        "datacite": "http://purl.org/spar/datacite/",
+        "earthcollab": "https://library.ucar.edu/earthcollab/schema#",
+        "geolink": "http://schema.geolink.org/1.0/base/main#",
+        "vivo": "http://vivoweb.org/ontology/core#",
+        "dcat": "http://www.w3.org/ns/dcat#"
+    },
+    "@id": " DOI:10.1594/IEDA/324328",
+    "@type": "Dataset",
+    "additionalType": [
+        "geolink:Dataset",
+        "vivo:Dataset"
+    ],
+    "name": "Hypocenter Catalog Data from the Mid-Atlantic Ridge - Rainbow Vent Field acquired in 2013",
+    "citation": "Sohn, Robert, Canales, JuanPablo, Dunn, Robert (2018), Hypocenter Catalog Data from the Mid-Atlantic Ridge - Rainbow Vent Field acquired in 2013. Integrated Earth Data Applications (IEDA). doi:10.1594/IEDA/324328",
+    "creator": [
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Sohn, Robert"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Canales, JuanPablo"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Dunn, Robert"
+        }
+    ],
+    "datePublished": "2018",
+    "dateCreated": "2018-01-11",
+    "version": "1",
+    "inLanguage": "en",
+    "description": "Abstract: This data set was acquired with Scripps Institution of Oceanography LC4X4 Ocean Bottom Seismometers deployed during R/V Marcus G. Langseth expedition MGL1305 in 2013 (Chief Scientist: Dr. Juan Pablo Canales, Investigators: Dr. Robert Sohn, Dr. Juan Pablo Canales, Dr. Robert Dunn). OBS recovery took place during R/V Pelagia cruise 64PE382. These data files are of Text File (ASCII) format and include Hypocenter Catalog data that were processed after acquisition. The hypocenter catalog is in space delimited text (ASCII) format. The first column is the event origin time. Note that depth is relative to sea level (i.e., -3.0 equals 3 km below sea level). The RMS value is the misfit of the hypocenter location, and only those events with RMS < 0.2 s were published in the journal article, but all locatable events are listed in this catalog. Data were acquired as part of the project(s): Collaborative Research: MARINER: Seismic Investigation of the Rainbow Hydrothermal Field and its Tectono/magmatic Setting, Mid-Atlantic Ridge 36 Degrees 14'N. Funding was provided by NSF award OCE09-61680.",
+    "distribution": [{
+        "@type": "DataDownload",
+        "additionalType": "dcat:distribution",
+        "name": "DOI landing page",
+        "dcat:accessURL": "http://dx.doi.org/10.1594/IEDA/324328",
+        "url": "http://dx.doi.org/10.1594/IEDA/324328",
+        "encodingFormat": "text/plain"
+    }],
+    "identifier": [
+        {
+            "@id": " doi:10.1594/IEDA/324328",
+            "@type": "PropertyValue",
+            "additionalType": [
+                "geolink:Identifier",
+                "datacite:Identifier"
+            ],
+            "propertyID": "datacite:doi",
+            "url": "http://dx.doi.org/10.1594/IEDA/324328",
+            "value": "10.1594/IEDA/324328"
+        },
+        {
+            "@id": "24328",
+            "@type": "PropertyValue",
+            "additionalType": [
+                "geolink:Identifier",
+                "datacite:Identifier"
+            ],
+            "propertyID": "MGDS",
+            "value": "24328"
+        }
+    ],
+    "keywords": ["Earthquake:Catalog"],
+    "license": "Creative Commons Attribution-NonCommercial-Share Alike 3.0 United States [CC BY-NC-SA 3.0]",
+    "provider": {
+        "@type": "Organization",
+        "@id": "https://www.iedadata.org/",
+        "name": "Interdisciplinary Earth Data Alliance (IEDA)"
+    },
+    "publisher": {
+        "@type": "Organization",
+        "@id": "https://www.iedadata.org/",
+        "name": "Interdisciplinary Earth Data Alliance (IEDA)",
+        "url": "https://www.iedadata.org/",
+        "description": "The IEDA data facility mission is to support, sustain, and advance the geosciences by providing data services for observational geoscience data from the Ocean, Earth, and Polar Sciences. IEDA systems serve as primary community data collections for global geochemistry and marine geoscience research and support the preservation, discovery, retrieval, and analysis of a wide range of observational field and analytical data types. Our tools and services are designed to facilitate data discovery and reuse for focused disciplinary research and to support interdisciplinary research and data integration.",
+        "logo": {
+            "@type": "ImageObject",
+            "url": ""
+        },
+        "contactPoint": {
+            "@type": "ContactPoint",
+            "name": "Kerstin Lehnert",
+            "email": "lehnert@ldeo.columbia.edu",
+            "url": "http://orcid.org/0000-0001-7036-1977",
+            "contactType": "Director"
+        },
+        "parentOrganization": {
+            "@type": "Organization",
+            "@id": "https://viaf.org/viaf/142992181/",
+            "name": "Lamont-Doherty Earth Observatory",
+            "url": "http://www.ldeo.columbia.edu/",
+            "address": {
+                "@type": "PostalAddress",
+                "streetAddress": "61 Route 9W",
+                "addressLocality": "Palisades",
+                "addressRegion": "NY",
+                "postalCode": "10964-1000",
+                "addressCountry": "USA"
+            },
+            "parentOrganization": {
+                "@type": "Organization",
+                "@id": "https://viaf.org/viaf/156836332/",
+                "legalName": "Columbia University",
+                "url": "http://www.columbia.edu/"
+            }
+        },
+        "funder": {
+            "@type": "Organization",
+            "@id": "http://dx.doi.org/10.13039/100000085",
+            "legalName": "Directorate for Geosciences",
+            "alternateName": "NSF-GEO",
+            "url": "http://www.nsf.gov",
+            "parentOrganization": {
+                "@type": "Organization",
+                "@id": "http://dx.doi.org/10.13039/100000001",
+                "legalName": "National Science Foundation",
+                "alternateName": "NSF",
+                "url": "http://www.nsf.gov"
+            }
+        },
+        "publishingPrinciples": {
+            "@id": "http://creativecommons.org/licenses/by-nc-sa/3.0/us/",
+            "@type": "DigitalDocument",
+            "additionalType": "gdx:Protocol-License",
+            "name": "Dataset Usage License",
+            "description": "Creative Commons Attribution-NonCommercial-Share Alike 3.0 United States [CC BY-NC-SA 3.0]",
+            "url": "https://creativecommons.org/licenses/by-nc-sa/3.0/us/"
+        }
+    },
+    "spatialCoverage": [{
+        "@type": "Place",
+        "geo": {
+            "@type": "GeoShape",
+            "box": "-33.888098, 36.229526 -33.887742, 36.229814"
+        }
+    }]
+}

--- a/DataCite2SDO/ExampleOutput/DataCite-10.2314_gbv_1010756656xx.json
+++ b/DataCite2SDO/ExampleOutput/DataCite-10.2314_gbv_1010756656xx.json
@@ -1,0 +1,110 @@
+{
+    "@context": {
+        "@vocab": "http://schema.org/",
+        "datacite": "http://purl.org/spar/datacite/",
+        "earthcollab": "https://library.ucar.edu/earthcollab/schema#",
+        "geolink": "http://schema.geolink.org/1.0/base/main#",
+        "vivo": "http://vivoweb.org/ontology/core#",
+        "dcat": "http://www.w3.org/ns/dcat#"
+    },
+    "@id": " DOI:10.2314/GBV:1010756656",
+    "@type": "Dataset",
+    "additionalType": [
+        "geolink:Dataset",
+        "vivo:Dataset"
+    ],
+    "name": "Qualifizierung innovativer Extinktionsphotometrie : Verbundprojekt: Innovative Extinktionsphotometrie zur Charakterisierung eines Mehrkomponenten-Aerosols und zur Feuchtemessung (IN-EX) : Abschlussbericht zum Teilprojekt A",
+    "alternateName": "Qualification of innovative extinction photometry (sub-project A of the joint-project \"Innovative extinction photometry for the characterisation of multicomponent-aerosol and humidity measurement (IN-EX\"))",
+    "citation": "Krupa, Björn Alexander, Technische Hochschule Aachen, Lehrstuhl für Reaktorsicherheit und -technik, Allelein, Hans-Josef (2017), Qualification of innovative extinction photometry (sub-project A of the joint-project \"Innovative extinction photometry for the characterisation of multicomponent-aerosol and humidity measurement (IN-EX\")). [Lehrstuhl für Reaktorsicherheit und -technik an der RWTH Aachen]. doi:10.2314/GBV:1010756656",
+    "creator": [
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Krupa, Björn Alexander"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Technische Hochschule Aachen, Lehrstuhl für Reaktorsicherheit und -technik"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Allelein, Hans-Josef"
+        }
+    ],
+    "datePublished": "2017",
+    "version": "1.0",
+    "inLanguage": "de",
+    "description": "",
+    "distribution": [{
+        "@type": "DataDownload",
+        "additionalType": "dcat:distribution",
+        "name": "DOI landing page",
+        "dcat:accessURL": "http://dx.doi.org/10.2314/GBV:1010756656",
+        "url": "http://dx.doi.org/10.2314/GBV:1010756656",
+        "encodingFormat": "application/pdf"
+    }],
+    "identifier": [
+        {
+            "@id": " doi:10.2314/GBV:1010756656",
+            "@type": "PropertyValue",
+            "additionalType": [
+                "geolink:Identifier",
+                "datacite:Identifier"
+            ],
+            "propertyID": "datacite:doi",
+            "url": "http://dx.doi.org/10.2314/GBV:1010756656",
+            "value": "10.2314/GBV:1010756656"
+        },
+        {
+            "@id": "GBV:1010756656",
+            "@type": "PropertyValue",
+            "additionalType": [
+                "geolink:Identifier",
+                "datacite:Identifier"
+            ],
+            "propertyID": "firstid",
+            "value": "GBV:1010756656"
+        },
+        {
+            "@id": "01130925",
+            "@type": "PropertyValue",
+            "additionalType": [
+                "geolink:Identifier",
+                "datacite:Identifier"
+            ],
+            "propertyID": "contract",
+            "value": "01130925"
+        },
+        {
+            "@id": "1010756656",
+            "@type": "PropertyValue",
+            "additionalType": [
+                "geolink:Identifier",
+                "datacite:Identifier"
+            ],
+            "propertyID": "ppn",
+            "value": "1010756656"
+        },
+        {
+            "@id": "TIBKAT:1010756656",
+            "@type": "PropertyValue",
+            "additionalType": [
+                "geolink:Identifier",
+                "datacite:Identifier"
+            ],
+            "propertyID": "ftx-id",
+            "value": "TIBKAT:1010756656"
+        }
+    ],
+    "keywords": ["Engineering"],
+    "provider": {
+        "@type": "Organization",
+        "name": "[Lehrstuhl für Reaktorsicherheit und -technik an der RWTH Aachen]"
+    },
+    "publisher": {
+        "@type": "Organization",
+        "name": "[Lehrstuhl für Reaktorsicherheit und -technik an der RWTH Aachen]"
+    }
+}

--- a/DataCite2SDO/ExampleOutput/DataCite-10.7283_r3t09nxx.json
+++ b/DataCite2SDO/ExampleOutput/DataCite-10.7283_r3t09nxx.json
@@ -1,0 +1,68 @@
+{
+    "@context": {
+        "@vocab": "http://schema.org/",
+        "datacite": "http://purl.org/spar/datacite/",
+        "earthcollab": "https://library.ucar.edu/earthcollab/schema#",
+        "geolink": "http://schema.geolink.org/1.0/base/main#",
+        "vivo": "http://vivoweb.org/ontology/core#",
+        "dcat": "http://www.w3.org/ns/dcat#"
+    },
+    "@id": " DOI:10.7283/R3T09N",
+    "@type": "Dataset",
+    "additionalType": [
+        "geolink:Dataset",
+        "vivo:Dataset"
+    ],
+    "name": "Tyndall Glacier Mass Balance TLS U-056 PS02 SV04",
+    "citation": "Dr. Dan McGrath, Brendan Hodge (2017), Tyndall Glacier Mass Balance TLS U-056 PS02 SV04. UNAVCO, Inc.. doi:10.7283/R3T09N",
+    "creator": [
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "@id": "http://orcid.org/0000-0002-9462-6842",
+            "name": "Dr. Dan McGrath"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "@id": "http://orcid.org/0000-0002-5719-5262",
+            "name": "Brendan Hodge"
+        }
+    ],
+    "datePublished": "2017",
+    "description": "",
+    "distribution": [{
+        "@type": "DataDownload",
+        "additionalType": "dcat:distribution",
+        "name": "DOI landing page",
+        "dcat:accessURL": "http://dx.doi.org/10.7283/R3T09N",
+        "url": "http://dx.doi.org/10.7283/R3T09N"
+    }],
+    "identifier": [{
+        "@id": " doi:10.7283/R3T09N",
+        "@type": "PropertyValue",
+        "additionalType": [
+            "geolink:Identifier",
+            "datacite:Identifier"
+        ],
+        "propertyID": "datacite:doi",
+        "url": "http://dx.doi.org/10.7283/R3T09N",
+        "value": "10.7283/R3T09N"
+    }],
+    "provider": {
+        "@type": "Organization",
+        "name": "UNAVCO, Inc."
+    },
+    "publisher": {
+        "@type": "Organization",
+        "name": "UNAVCO, Inc."
+    },
+    "spatialCoverage": [{
+        "@type": "Place",
+        "geo": [{
+            "@type": "GeoCoordinates",
+            "longitude": "-105.6893",
+            "latitude": "40.3052"
+        }]
+    }]
+}

--- a/DataCite2SDO/ExampleOutput/DataCite-10.7283_t5mc8xsqxx.json
+++ b/DataCite2SDO/ExampleOutput/DataCite-10.7283_t5mc8xsqxx.json
@@ -1,0 +1,67 @@
+{
+    "@context": {
+        "@vocab": "http://schema.org/",
+        "datacite": "http://purl.org/spar/datacite/",
+        "earthcollab": "https://library.ucar.edu/earthcollab/schema#",
+        "geolink": "http://schema.geolink.org/1.0/base/main#",
+        "vivo": "http://vivoweb.org/ontology/core#",
+        "dcat": "http://www.w3.org/ns/dcat#"
+    },
+    "@id": " DOI:10.7283/T5MC8XSQ",
+    "@type": "Dataset",
+    "additionalType": [
+        "geolink:Dataset",
+        "vivo:Dataset"
+    ],
+    "name": "RAPID Nevado del Ruiz Volcano GPS Network",
+    "alternateName": "PRMO-PRMO_NdR_COL2016 P.S.",
+    "citation": "Timothy H. Dixon, Glen Mattioli (2017), RAPID Nevado del Ruiz Volcano GPS Network. UNAVCO, Inc.. doi:10.7283/T5MC8XSQ",
+    "creator": [
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Timothy H. Dixon"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Glen Mattioli"
+        }
+    ],
+    "datePublished": "2017",
+    "description": "",
+    "distribution": [{
+        "@type": "DataDownload",
+        "additionalType": "dcat:distribution",
+        "name": "DOI landing page",
+        "dcat:accessURL": "http://dx.doi.org/10.7283/T5MC8XSQ",
+        "url": "http://dx.doi.org/10.7283/T5MC8XSQ"
+    }],
+    "identifier": [{
+        "@id": " doi:10.7283/T5MC8XSQ",
+        "@type": "PropertyValue",
+        "additionalType": [
+            "geolink:Identifier",
+            "datacite:Identifier"
+        ],
+        "propertyID": "datacite:doi",
+        "url": "http://dx.doi.org/10.7283/T5MC8XSQ",
+        "value": "10.7283/T5MC8XSQ"
+    }],
+    "provider": {
+        "@type": "Organization",
+        "name": "UNAVCO, Inc."
+    },
+    "publisher": {
+        "@type": "Organization",
+        "name": "UNAVCO, Inc."
+    },
+    "spatialCoverage": [{
+        "@type": "Place",
+        "geo": [{
+            "@type": "GeoCoordinates",
+            "longitude": "-75.451324",
+            "latitude": "4.801165"
+        }]
+    }]
+}

--- a/DataCite2SDO/ExampleOutput/phpDataCite0006-DOI100037.json
+++ b/DataCite2SDO/ExampleOutput/phpDataCite0006-DOI100037.json
@@ -1,0 +1,607 @@
+{
+    "@context": {
+        "@vocab": "http://schema.org/",
+        "datacite": "http://purl.org/spar/datacite/",
+        "earthcollab": "https://library.ucar.edu/earthcollab/schema#",
+        "geolink": "http://schema.geolink.org/1.0/base/main#",
+        "vivo": "http://vivoweb.org/ontology/core#",
+        "dcat": "http://www.w3.org/ns/dcat#"
+    },
+    "@id": " DOI:10.1594/IEDA/100037",
+    "@type": "Dataset",
+    "additionalType": [
+        "geolink:Dataset",
+        "vivo:Dataset"
+    ],
+    "name": "LauBasin_TUIM05MV_Mottl",
+    "citation": "Michael J. Mottl, Peter Michael, Jeffrey Seewald, Eoghan Reeves, Chen-Feng You, Thomas Pichler, Jessica Sharkey, Lui-Hueng Chan, Margaret K. Tivey, Giora Proskurowski, Geoffrey C. Wheat (2010), LauBasin_TUIM05MV_Mottl. Interdisciplinary Earth Data Alliance (IEDA). doi:10.1594/IEDA/100037",
+    "creator": [
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "@id": "https://www.scopus.com/authid/detail.uri?authorId=7004195161",
+            "name": "Michael J. Mottl",
+            "givenName": "Michael",
+            "familyName": "Mottl"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "@id": "http://orcid.org/0000-0003-2829-9502",
+            "name": "Peter Michael",
+            "givenName": "Peter",
+            "familyName": "Michael"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Jeffrey Seewald",
+            "givenName": "Jeffrey",
+            "familyName": "Seewald"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Eoghan Reeves",
+            "givenName": "Eoghan",
+            "familyName": "Reeves"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Chen-Feng You",
+            "givenName": "Chen-Feng",
+            "familyName": "You"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Thomas Pichler",
+            "givenName": "Thomas",
+            "familyName": "Pichler"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Jessica Sharkey",
+            "givenName": "Jessica",
+            "familyName": "Sharkey"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "@id": "https://www.scopus.com/authid/detail.uri?authorId=7403540481",
+            "name": "Lui-Hueng Chan",
+            "givenName": "Lui-Hueng",
+            "familyName": "Chan"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Margaret K. Tivey",
+            "givenName": "Margaret",
+            "familyName": "Tivey"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Giora Proskurowski",
+            "givenName": "Giora",
+            "familyName": "Proskurowski"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Geoffrey C. Wheat",
+            "givenName": "Geoffrey",
+            "familyName": "Wheat"
+        }
+    ],
+    "datePublished": "2010",
+    "description": "Abstract: Collection of hydrothermal vent fluid chemistry data from  the Eastern Lau Spreading Center. This file is just one part of a much larger effort (VentDB) to make available to the scientific community as much hydrothermal ridge vent chemistry data as possible (for a list of all the VentDB related data collections available, search the EarthChem Library for the term \u201cVentDB\u201d). For more information about this compilation, please see \"Explanatory Notes and Master Chemical Item Spreadsheet for the VentDB Data Collections housed in the EarthChem Library\" (M. Mottl), available at www.earthchem.org/library.;       Other Description: Mottl, M.J. et al., (2011), Chemistry of hot springs along the Eastern Lau Spreading Center, Geochimica et Cosmochimica Acta, 75(4), 1013-1038.",
+    "distribution": [
+        {
+            "@type": "DataDownload",
+            "additionalType": "dcat:distribution",
+            "name": "DOI landing page",
+            "dcat:accessURL": "http://dx.doi.org/10.1594/IEDA/100037",
+            "url": "http://dx.doi.org/10.1594/IEDA/100037",
+            "encodingFormat": "application/vnd.ms-excel"
+        },
+        {
+            "@type": "DataDownload",
+            "additionalType": "dcat:distribution",
+            "name": "URL",
+            "dcat:accessURL": "http://www.earthchem.org/library/browse/view?id=6",
+            "url": "http://www.earthchem.org/library/browse/view?id=6",
+            "encodingFormat": "application/vnd.ms-excel"
+        }
+    ],
+    "identifier": [{
+        "@id": " doi:10.1594/IEDA/100037",
+        "@type": "PropertyValue",
+        "additionalType": [
+            "geolink:Identifier",
+            "datacite:Identifier"
+        ],
+        "propertyID": "datacite:doi",
+        "url": "http://dx.doi.org/10.1594/IEDA/100037",
+        "value": "10.1594/IEDA/100037"
+    }],
+    "isPartOf": [{
+        "@id": "http://www.nsf.gov/awardsearch/showAward.do?AwardNumber=0241826",
+        "@type": "CreativeWork",
+        "additionalType": "earthcollab:Project",
+        "funder": {
+            "@type": "Organization",
+            "name": "National Science Foundation"
+        }
+    }],
+    "keywords": [
+        "Regional (Continents, Oceans)",
+        "Back Arc Basin",
+        "Hydrothermal Vent",
+        "Spreading Center",
+        "Chemistry:Fluid",
+        "Geochemistry",
+        "Marine Geoscience",
+        "Solid Earth",
+        "Eastern Lau Basin Spreading Center",
+        "R2K (Ridge 2000) funded",
+        "TUIM05MV",
+        "Lau Basin",
+        "Pacific Ocean",
+        "Lau Basin, Pacific"
+    ],
+    "license": "Creative Commons Attribution-NonCommercial-Share Alike 3.0 United States [CC BY-NC-SA 3.0]",
+    "provider": {
+        "@type": "Organization",
+        "@id": "https://www.iedadata.org/",
+        "name": "Interdisciplinary Earth Data Alliance (IEDA)"
+    },
+    "publisher": {
+        "@type": "Organization",
+        "@id": "https://www.iedadata.org/",
+        "name": "Interdisciplinary Earth Data Alliance (IEDA)",
+        "url": "https://www.iedadata.org/",
+        "description": "The IEDA data facility mission is to support, sustain, and advance the geosciences by providing data services for observational geoscience data from the Ocean, Earth, and Polar Sciences. IEDA systems serve as primary community data collections for global geochemistry and marine geoscience research and support the preservation, discovery, retrieval, and analysis of a wide range of observational field and analytical data types. Our tools and services are designed to facilitate data discovery and reuse for focused disciplinary research and to support interdisciplinary research and data integration.",
+        "logo": {
+            "@type": "ImageObject",
+            "url": ""
+        },
+        "contactPoint": {
+            "@type": "ContactPoint",
+            "name": "Kerstin Lehnert",
+            "email": "lehnert@ldeo.columbia.edu",
+            "url": "http://orcid.org/0000-0001-7036-1977",
+            "contactType": "Director"
+        },
+        "parentOrganization": {
+            "@type": "Organization",
+            "@id": "https://viaf.org/viaf/142992181/",
+            "name": "Lamont-Doherty Earth Observatory",
+            "url": "http://www.ldeo.columbia.edu/",
+            "address": {
+                "@type": "PostalAddress",
+                "streetAddress": "61 Route 9W",
+                "addressLocality": "Palisades",
+                "addressRegion": "NY",
+                "postalCode": "10964-1000",
+                "addressCountry": "USA"
+            },
+            "parentOrganization": {
+                "@type": "Organization",
+                "@id": "https://viaf.org/viaf/156836332/",
+                "legalName": "Columbia University",
+                "url": "http://www.columbia.edu/"
+            }
+        },
+        "funder": {
+            "@type": "Organization",
+            "@id": "http://dx.doi.org/10.13039/100000085",
+            "legalName": "Directorate for Geosciences",
+            "alternateName": "NSF-GEO",
+            "url": "http://www.nsf.gov",
+            "parentOrganization": {
+                "@type": "Organization",
+                "@id": "http://dx.doi.org/10.13039/100000001",
+                "legalName": "National Science Foundation",
+                "alternateName": "NSF",
+                "url": "http://www.nsf.gov"
+            }
+        },
+        "publishingPrinciples": {
+            "@id": "http://creativecommons.org/licenses/by-nc-sa/3.0/us/",
+            "@type": "DigitalDocument",
+            "additionalType": "gdx:Protocol-License",
+            "name": "Dataset Usage License",
+            "description": "Creative Commons Attribution-NonCommercial-Share Alike 3.0 United States [CC BY-NC-SA 3.0]",
+            "url": "https://creativecommons.org/licenses/by-nc-sa/3.0/us/"
+        }
+    },
+    "spatialCoverage": [
+        {
+            "@type": "Place",
+            "name": "Lau Basin, Pacific",
+            "geo": [
+                {
+                    "@type": "GeoShape",
+                    "box": "-176.6085, -22.2157 -176.1334, -20.0526"
+                },
+                {
+                    "@type": "GeoCoordinates",
+                    "longitude": "-176.6085",
+                    "latitude": "-22.2157"
+                }
+            ]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.6084",
+                "latitude": "-22.2155"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.6079",
+                "latitude": "-22.2142"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.602",
+                "latitude": "-22.1817"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.602",
+                "latitude": "-22.1816"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.6012",
+                "latitude": "-22.1807"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.6017",
+                "latitude": "-22.1806"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.6015",
+                "latitude": "-22.1805"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.6015",
+                "latitude": "-22.1804"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.6009",
+                "latitude": "-22.1802"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.601",
+                "latitude": "-22.1801"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.5689",
+                "latitude": "-21.991"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.5691",
+                "latitude": "-21.9906"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.5689",
+                "latitude": "-21.9902"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.5682",
+                "latitude": "-21.9897"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.5685",
+                "latitude": "-21.9884"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.5677",
+                "latitude": "-21.988"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.5679",
+                "latitude": "-21.9879"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.5679",
+                "latitude": "-21.9878"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1921",
+                "latitude": "-20.7665"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1931",
+                "latitude": "-20.7659"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1915",
+                "latitude": "-20.7633"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1914",
+                "latitude": "-20.7633"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1912",
+                "latitude": "-20.763"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1911",
+                "latitude": "-20.7627"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1907",
+                "latitude": "-20.7612"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1896",
+                "latitude": "-20.761"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.191",
+                "latitude": "-20.7609"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1912",
+                "latitude": "-20.7603"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1909",
+                "latitude": "-20.7603"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1374",
+                "latitude": "-20.3179"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1374",
+                "latitude": "-20.3178"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.137",
+                "latitude": "-20.3178"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1372",
+                "latitude": "-20.3177"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1366",
+                "latitude": "-20.3167"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1365",
+                "latitude": "-20.3167"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1363",
+                "latitude": "-20.3167"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1362",
+                "latitude": "-20.3166"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1365",
+                "latitude": "-20.3164"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1363",
+                "latitude": "-20.3164"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1337",
+                "latitude": "-20.0539"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1335",
+                "latitude": "-20.0539"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1334",
+                "latitude": "-20.0537"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1337",
+                "latitude": "-20.0531"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1337",
+                "latitude": "-20.053"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1338",
+                "latitude": "-20.0526"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-176.1335",
+                "latitude": "-20.0526"
+            }]
+        }
+    ]
+}

--- a/DataCite2SDO/ExampleOutput/phpDataCite0263-DOI100051.json
+++ b/DataCite2SDO/ExampleOutput/phpDataCite0263-DOI100051.json
@@ -1,0 +1,160 @@
+{
+    "@context": {
+        "@vocab": "http://schema.org/",
+        "datacite": "http://purl.org/spar/datacite/",
+        "earthcollab": "https://library.ucar.edu/earthcollab/schema#",
+        "geolink": "http://schema.geolink.org/1.0/base/main#",
+        "vivo": "http://vivoweb.org/ontology/core#",
+        "dcat": "http://www.w3.org/ns/dcat#"
+    },
+    "@id": " DOI:10.1594/IEDA/100051",
+    "@type": "Dataset",
+    "additionalType": [
+        "geolink:Dataset",
+        "vivo:Dataset"
+    ],
+    "name": "Chemical analyses for \"Water and the Oxidation State of Subduction Zone Magmas\"",
+    "citation": "Katherine A. Kelley, Elizabeth Cottrell (2012), Chemical analyses for \"Water and the Oxidation State of Subduction Zone Magmas\". Interdisciplinary Earth Data Alliance (IEDA). doi:10.1594/IEDA/100051",
+    "creator": [
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "@id": "https://www.scopus.com/authid/detail.uri?authorId=35229996900",
+            "name": "Katherine A. Kelley",
+            "givenName": "Katherine",
+            "familyName": "Kelley"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "@id": "https://www.scopus.com/authid/detail.uri?authorId=55881957900",
+            "name": "Elizabeth Cottrell",
+            "givenName": "Elizabeth",
+            "familyName": "Cottrell"
+        }
+    ],
+    "datePublished": "2012",
+    "description": "Abstract: Three supplemental tables from Kelley and Cottrell, \"Water and the Oxidation State of Subduction Zone Magmas\" (Science, 2009). Major and volatile element concentrations and Fe+3/Fe_Tot ratios for MORB, BABB, and olivine-hosted melt inclusions; corrected melt compositions for olivine-hosted melt inclusions; and average Fe+3/Fe_tot and Ba/La for MORB and Mariana trough/arc.;       Other Description: Kelley, K.A. and E. Cottrell (2009), Water and the Oxidation State of Subduction Zone Magmas, Science, 325, 605-607.",
+    "distribution": [
+        {
+            "@type": "DataDownload",
+            "additionalType": "dcat:distribution",
+            "name": "DOI landing page",
+            "dcat:accessURL": "http://dx.doi.org/10.1594/IEDA/100051",
+            "url": "http://dx.doi.org/10.1594/IEDA/100051",
+            "encodingFormat": "application/vnd.ms-excel"
+        },
+        {
+            "@type": "DataDownload",
+            "additionalType": "dcat:distribution",
+            "name": "URL",
+            "dcat:accessURL": "http://www.earthchem.org/library/browse/view?id=263",
+            "url": "http://www.earthchem.org/library/browse/view?id=263",
+            "encodingFormat": "application/vnd.ms-excel"
+        }
+    ],
+    "identifier": [{
+        "@id": " doi:10.1594/IEDA/100051",
+        "@type": "PropertyValue",
+        "additionalType": [
+            "geolink:Identifier",
+            "datacite:Identifier"
+        ],
+        "propertyID": "datacite:doi",
+        "url": "http://dx.doi.org/10.1594/IEDA/100051",
+        "value": "10.1594/IEDA/100051"
+    }],
+    "isPartOf": [{
+        "@id": "http://www.nsf.gov/awardsearch/showAward.do?AwardNumber=0841108",
+        "@type": "CreativeWork",
+        "additionalType": "earthcollab:Project",
+        "funder": {
+            "@type": "Organization",
+            "name": "National Science Foundation"
+        }
+    }],
+    "keywords": [
+        "Regional (Continents, Oceans)",
+        "Back Arc Basin",
+        "Subduction Zone",
+        "Chemistry:Rock",
+        "Geochemistry",
+        "Marine Geoscience",
+        "Solid Earth",
+        "BABB",
+        "Margins related",
+        "MORB",
+        "subduction zone",
+        "Mariana subduction zone"
+    ],
+    "license": "Creative Commons Attribution-NonCommercial-Share Alike 3.0 United States [CC BY-NC-SA 3.0]",
+    "provider": {
+        "@type": "Organization",
+        "@id": "https://www.iedadata.org/",
+        "name": "Interdisciplinary Earth Data Alliance (IEDA)"
+    },
+    "publisher": {
+        "@type": "Organization",
+        "@id": "https://www.iedadata.org/",
+        "name": "Interdisciplinary Earth Data Alliance (IEDA)",
+        "url": "https://www.iedadata.org/",
+        "description": "The IEDA data facility mission is to support, sustain, and advance the geosciences by providing data services for observational geoscience data from the Ocean, Earth, and Polar Sciences. IEDA systems serve as primary community data collections for global geochemistry and marine geoscience research and support the preservation, discovery, retrieval, and analysis of a wide range of observational field and analytical data types. Our tools and services are designed to facilitate data discovery and reuse for focused disciplinary research and to support interdisciplinary research and data integration.",
+        "logo": {
+            "@type": "ImageObject",
+            "url": ""
+        },
+        "contactPoint": {
+            "@type": "ContactPoint",
+            "name": "Kerstin Lehnert",
+            "email": "lehnert@ldeo.columbia.edu",
+            "url": "http://orcid.org/0000-0001-7036-1977",
+            "contactType": "Director"
+        },
+        "parentOrganization": {
+            "@type": "Organization",
+            "@id": "https://viaf.org/viaf/142992181/",
+            "name": "Lamont-Doherty Earth Observatory",
+            "url": "http://www.ldeo.columbia.edu/",
+            "address": {
+                "@type": "PostalAddress",
+                "streetAddress": "61 Route 9W",
+                "addressLocality": "Palisades",
+                "addressRegion": "NY",
+                "postalCode": "10964-1000",
+                "addressCountry": "USA"
+            },
+            "parentOrganization": {
+                "@type": "Organization",
+                "@id": "https://viaf.org/viaf/156836332/",
+                "legalName": "Columbia University",
+                "url": "http://www.columbia.edu/"
+            }
+        },
+        "funder": {
+            "@type": "Organization",
+            "@id": "http://dx.doi.org/10.13039/100000085",
+            "legalName": "Directorate for Geosciences",
+            "alternateName": "NSF-GEO",
+            "url": "http://www.nsf.gov",
+            "parentOrganization": {
+                "@type": "Organization",
+                "@id": "http://dx.doi.org/10.13039/100000001",
+                "legalName": "National Science Foundation",
+                "alternateName": "NSF",
+                "url": "http://www.nsf.gov"
+            }
+        },
+        "publishingPrinciples": {
+            "@id": "http://creativecommons.org/licenses/by-nc-sa/3.0/us/",
+            "@type": "DigitalDocument",
+            "additionalType": "gdx:Protocol-License",
+            "name": "Dataset Usage License",
+            "description": "Creative Commons Attribution-NonCommercial-Share Alike 3.0 United States [CC BY-NC-SA 3.0]",
+            "url": "https://creativecommons.org/licenses/by-nc-sa/3.0/us/"
+        }
+    },
+    "spatialCoverage": [{
+        "@type": "Place",
+        "name": "Mariana subduction zone"
+    }]
+}

--- a/DataCite2SDO/ExampleOutput/phpDataCite0774-DOI100461.json
+++ b/DataCite2SDO/ExampleOutput/phpDataCite0774-DOI100461.json
@@ -1,0 +1,193 @@
+{
+    "@context": {
+        "@vocab": "http://schema.org/",
+        "datacite": "http://purl.org/spar/datacite/",
+        "earthcollab": "https://library.ucar.edu/earthcollab/schema#",
+        "geolink": "http://schema.geolink.org/1.0/base/main#",
+        "vivo": "http://vivoweb.org/ontology/core#",
+        "dcat": "http://www.w3.org/ns/dcat#"
+    },
+    "@id": " DOI:10.1594/IEDA/100461",
+    "@type": "Dataset",
+    "additionalType": [
+        "geolink:Dataset",
+        "vivo:Dataset"
+    ],
+    "name": "New York Weather Station Data (2012)",
+    "citation": "Susan L. Brantley, Tim White, Collin Duffy, Di Keller, Ashlee L. Dere, Rich April (2014), New York Weather Station Data (2012). Interdisciplinary Earth Data Alliance (IEDA). doi:10.1594/IEDA/100461",
+    "creator": [
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Susan L. Brantley",
+            "givenName": "Susan",
+            "familyName": "Brantley"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Tim White",
+            "givenName": "Tim",
+            "familyName": "White"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Collin Duffy",
+            "givenName": "Collin",
+            "familyName": "Duffy"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Di Keller",
+            "givenName": "Di",
+            "familyName": "Keller"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Ashlee L. Dere",
+            "givenName": "Ashlee",
+            "familyName": "Dere"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Rich April",
+            "givenName": "Rich",
+            "familyName": "April"
+        }
+    ],
+    "datePublished": "2014",
+    "description": "Abstract: Weather stations deployed across the Critical Zone Observatory (CZO) Shale Transect, including sites in New York, Virginia, Tennessee, Alabama and Puerto Rico, provide continuous measurements of climatic conditions influencing shale weathering. Measurements are recorded every two hours and include precipitation, air temperature, relative humidity, solar radiation, wind speed, soil temperature, soil moisture and soil electrical conductivity. ; Other Description: Ashlee Dere, (2014), Rates and mechanisms of shale weathering across a latitudinal climosequence, Ph.D. Dissertation, The Pennsylvania State University",
+    "distribution": [
+        {
+            "@type": "DataDownload",
+            "additionalType": "dcat:distribution",
+            "name": "DOI landing page",
+            "dcat:accessURL": "http://dx.doi.org/10.1594/IEDA/100461",
+            "url": "http://dx.doi.org/10.1594/IEDA/100461",
+            "encodingFormat": "application/vnd.ms-excel"
+        },
+        {
+            "@type": "DataDownload",
+            "additionalType": "dcat:distribution",
+            "name": "URL",
+            "dcat:accessURL": "http://www.earthchem.org/library/browse/view?id=774",
+            "url": "http://www.earthchem.org/library/browse/view?id=774",
+            "encodingFormat": "application/vnd.ms-excel"
+        }
+    ],
+    "identifier": [{
+        "@id": " doi:10.1594/IEDA/100461",
+        "@type": "PropertyValue",
+        "additionalType": [
+            "geolink:Identifier",
+            "datacite:Identifier"
+        ],
+        "propertyID": "datacite:doi",
+        "url": "http://dx.doi.org/10.1594/IEDA/100461",
+        "value": "10.1594/IEDA/100461"
+    }],
+    "isPartOf": [{
+        "@id": "http://www.nsf.gov/awardsearch/showAward.do?AwardNumber=0725019",
+        "@type": "CreativeWork",
+        "additionalType": "earthcollab:Project",
+        "funder": {
+            "@type": "Organization",
+            "name": "National Science Foundation"
+        }
+    }],
+    "keywords": [
+        "Regional (Continents, Oceans)",
+        "NearSurface/CriticalZone",
+        "Environmental data",
+        "air temperature",
+        "CZO",
+        "precipitation",
+        "relative humidity",
+        "Shale Transect",
+        "soil electrical conductivity",
+        "soil moisture",
+        "soil temperature",
+        "solar radiation",
+        "wind speed",
+        "New York"
+    ],
+    "license": "Creative Commons Attribution-NonCommercial-Share Alike 3.0 United States [CC BY-NC-SA 3.0]",
+    "provider": {
+        "@type": "Organization",
+        "@id": "https://www.iedadata.org/",
+        "name": "Interdisciplinary Earth Data Alliance (IEDA)"
+    },
+    "publisher": {
+        "@type": "Organization",
+        "@id": "https://www.iedadata.org/",
+        "name": "Interdisciplinary Earth Data Alliance (IEDA)",
+        "url": "https://www.iedadata.org/",
+        "description": "The IEDA data facility mission is to support, sustain, and advance the geosciences by providing data services for observational geoscience data from the Ocean, Earth, and Polar Sciences. IEDA systems serve as primary community data collections for global geochemistry and marine geoscience research and support the preservation, discovery, retrieval, and analysis of a wide range of observational field and analytical data types. Our tools and services are designed to facilitate data discovery and reuse for focused disciplinary research and to support interdisciplinary research and data integration.",
+        "logo": {
+            "@type": "ImageObject",
+            "url": ""
+        },
+        "contactPoint": {
+            "@type": "ContactPoint",
+            "name": "Kerstin Lehnert",
+            "email": "lehnert@ldeo.columbia.edu",
+            "url": "http://orcid.org/0000-0001-7036-1977",
+            "contactType": "Director"
+        },
+        "parentOrganization": {
+            "@type": "Organization",
+            "@id": "https://viaf.org/viaf/142992181/",
+            "name": "Lamont-Doherty Earth Observatory",
+            "url": "http://www.ldeo.columbia.edu/",
+            "address": {
+                "@type": "PostalAddress",
+                "streetAddress": "61 Route 9W",
+                "addressLocality": "Palisades",
+                "addressRegion": "NY",
+                "postalCode": "10964-1000",
+                "addressCountry": "USA"
+            },
+            "parentOrganization": {
+                "@type": "Organization",
+                "@id": "https://viaf.org/viaf/156836332/",
+                "legalName": "Columbia University",
+                "url": "http://www.columbia.edu/"
+            }
+        },
+        "funder": {
+            "@type": "Organization",
+            "@id": "http://dx.doi.org/10.13039/100000085",
+            "legalName": "Directorate for Geosciences",
+            "alternateName": "NSF-GEO",
+            "url": "http://www.nsf.gov",
+            "parentOrganization": {
+                "@type": "Organization",
+                "@id": "http://dx.doi.org/10.13039/100000001",
+                "legalName": "National Science Foundation",
+                "alternateName": "NSF",
+                "url": "http://www.nsf.gov"
+            }
+        },
+        "publishingPrinciples": {
+            "@id": "http://creativecommons.org/licenses/by-nc-sa/3.0/us/",
+            "@type": "DigitalDocument",
+            "additionalType": "gdx:Protocol-License",
+            "name": "Dataset Usage License",
+            "description": "Creative Commons Attribution-NonCommercial-Share Alike 3.0 United States [CC BY-NC-SA 3.0]",
+            "url": "https://creativecommons.org/licenses/by-nc-sa/3.0/us/"
+        }
+    },
+    "spatialCoverage": [{
+        "@type": "Place",
+        "name": "New York",
+        "geo": [{
+            "@type": "GeoCoordinates",
+            "longitude": "-75.276067",
+            "latitude": "43.031717"
+        }]
+    }]
+}

--- a/DataCite2SDO/ExampleOutput/phpDataCite1064-DOI100682.json
+++ b/DataCite2SDO/ExampleOutput/phpDataCite1064-DOI100682.json
@@ -1,0 +1,2461 @@
+{
+    "@context": {
+        "@vocab": "http://schema.org/",
+        "datacite": "http://purl.org/spar/datacite/",
+        "earthcollab": "https://library.ucar.edu/earthcollab/schema#",
+        "geolink": "http://schema.geolink.org/1.0/base/main#",
+        "vivo": "http://vivoweb.org/ontology/core#",
+        "dcat": "http://www.w3.org/ns/dcat#"
+    },
+    "@id": " DOI:10.1594/IEDA/100682",
+    "@type": "Dataset",
+    "additionalType": [
+        "geolink:Dataset",
+        "vivo:Dataset"
+    ],
+    "name": "Major and trace-element analyses of Cenozoic volcanic rocks from southern Oregon, northern Nevada, and northeastern California",
+    "citation": "Victor E. Camp, Martin E. Ross (2017), Major and trace-element analyses of Cenozoic volcanic rocks from southern Oregon, northern Nevada, and northeastern California. Interdisciplinary Earth Data Alliance (IEDA). doi:10.1594/IEDA/100682",
+    "creator": [
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Victor E. Camp",
+            "givenName": "Victor",
+            "familyName": "Camp"
+        },
+        {
+            "@type": "Person",
+            "additionalType": "geolink:Person",
+            "name": "Martin E. Ross",
+            "givenName": "Martin",
+            "familyName": "Ross"
+        }
+    ],
+    "datePublished": "2017",
+    "description": "Abstract: Major- and trace-element XRF analyses on two-hundred and ninety-nine Cenozoic volcanic rocks in southeastern Oregon northern Nevada, and northeastern California. These analyses are subdivided into 30-20 Ma rocks of ancestral Northern Cascade back-arc region, 16.7-15 Ma rocks of the Columbia Basin-Nevada magmatic belt, and 16.7-8 Ma rocks of the southern segment of the ancestral Cascades in the Oregon-Nevada-California tri-state region.",
+    "distribution": [
+        {
+            "@type": "DataDownload",
+            "additionalType": "dcat:distribution",
+            "name": "DOI landing page",
+            "dcat:accessURL": "http://dx.doi.org/10.1594/IEDA/100682",
+            "url": "http://dx.doi.org/10.1594/IEDA/100682",
+            "encodingFormat": "application/vnd.ms-excel"
+        },
+        {
+            "@type": "DataDownload",
+            "additionalType": "dcat:distribution",
+            "name": "URL",
+            "dcat:accessURL": "http://www.earthchem.org/library/browse/view?id=1064",
+            "url": "http://www.earthchem.org/library/browse/view?id=1064",
+            "encodingFormat": "application/vnd.ms-excel"
+        }
+    ],
+    "identifier": [{
+        "@id": " doi:10.1594/IEDA/100682",
+        "@type": "PropertyValue",
+        "additionalType": [
+            "geolink:Identifier",
+            "datacite:Identifier"
+        ],
+        "propertyID": "datacite:doi",
+        "url": "http://dx.doi.org/10.1594/IEDA/100682",
+        "value": "10.1594/IEDA/100682"
+    }],
+    "keywords": [
+        "Regional (Continents, Oceans)",
+        "Chemistry:Rock",
+        "Geochemistry",
+        "Solid Earth",
+        "Ancestral Cascade arc",
+        "Columbia River Basalt",
+        "mantle plume",
+        "Oregon back-arc",
+        "Yellowstone hotspot",
+        "California",
+        "Nevada",
+        "Oregon",
+        "Pacific northwest",
+        "United States",
+        "Pacific northwest,Oregon, Nevada, California, United States"
+    ],
+    "license": "Creative Commons Attribution-NonCommercial-Share Alike 3.0 United States [CC BY-NC-SA 3.0]",
+    "provider": {
+        "@type": "Organization",
+        "@id": "https://www.iedadata.org/",
+        "name": "Interdisciplinary Earth Data Alliance (IEDA)"
+    },
+    "publisher": {
+        "@type": "Organization",
+        "@id": "https://www.iedadata.org/",
+        "name": "Interdisciplinary Earth Data Alliance (IEDA)",
+        "url": "https://www.iedadata.org/",
+        "description": "The IEDA data facility mission is to support, sustain, and advance the geosciences by providing data services for observational geoscience data from the Ocean, Earth, and Polar Sciences. IEDA systems serve as primary community data collections for global geochemistry and marine geoscience research and support the preservation, discovery, retrieval, and analysis of a wide range of observational field and analytical data types. Our tools and services are designed to facilitate data discovery and reuse for focused disciplinary research and to support interdisciplinary research and data integration.",
+        "logo": {
+            "@type": "ImageObject",
+            "url": ""
+        },
+        "contactPoint": {
+            "@type": "ContactPoint",
+            "name": "Kerstin Lehnert",
+            "email": "lehnert@ldeo.columbia.edu",
+            "url": "http://orcid.org/0000-0001-7036-1977",
+            "contactType": "Director"
+        },
+        "parentOrganization": {
+            "@type": "Organization",
+            "@id": "https://viaf.org/viaf/142992181/",
+            "name": "Lamont-Doherty Earth Observatory",
+            "url": "http://www.ldeo.columbia.edu/",
+            "address": {
+                "@type": "PostalAddress",
+                "streetAddress": "61 Route 9W",
+                "addressLocality": "Palisades",
+                "addressRegion": "NY",
+                "postalCode": "10964-1000",
+                "addressCountry": "USA"
+            },
+            "parentOrganization": {
+                "@type": "Organization",
+                "@id": "https://viaf.org/viaf/156836332/",
+                "legalName": "Columbia University",
+                "url": "http://www.columbia.edu/"
+            }
+        },
+        "funder": {
+            "@type": "Organization",
+            "@id": "http://dx.doi.org/10.13039/100000085",
+            "legalName": "Directorate for Geosciences",
+            "alternateName": "NSF-GEO",
+            "url": "http://www.nsf.gov",
+            "parentOrganization": {
+                "@type": "Organization",
+                "@id": "http://dx.doi.org/10.13039/100000001",
+                "legalName": "National Science Foundation",
+                "alternateName": "NSF",
+                "url": "http://www.nsf.gov"
+            }
+        },
+        "publishingPrinciples": {
+            "@id": "http://creativecommons.org/licenses/by-nc-sa/3.0/us/",
+            "@type": "DigitalDocument",
+            "additionalType": "gdx:Protocol-License",
+            "name": "Dataset Usage License",
+            "description": "Creative Commons Attribution-NonCommercial-Share Alike 3.0 United States [CC BY-NC-SA 3.0]",
+            "url": "https://creativecommons.org/licenses/by-nc-sa/3.0/us/"
+        }
+    },
+    "spatialCoverage": [
+        {
+            "@type": "Place",
+            "name": "Pacific northwest,Oregon, Nevada, California, United States",
+            "geo": [
+                {
+                    "@type": "GeoShape",
+                    "box": "-120.613112, 40.352335 41.766282, 43.476502"
+                },
+                {
+                    "@type": "GeoCoordinates",
+                    "longitude": "-115.532247",
+                    "latitude": "40.352335"
+                }
+            ]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-115.572019",
+                "latitude": "40.355413"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-115.539969",
+                "latitude": "40.355481"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-115.539727",
+                "latitude": "40.367118"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-115.569374",
+                "latitude": "40.367387"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-115.574385",
+                "latitude": "40.374805"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.287958",
+                "latitude": "40.402885"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.14442",
+                "latitude": "40.428649"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.146745",
+                "latitude": "40.43009"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.147227",
+                "latitude": "40.431457"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.074595",
+                "latitude": "40.432589"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.074896",
+                "latitude": "40.432807"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.323356",
+                "latitude": "40.433364"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.308024",
+                "latitude": "40.435053"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.32852",
+                "latitude": "40.43535"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.346823",
+                "latitude": "40.435978"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.335673",
+                "latitude": "40.43939"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.963544",
+                "latitude": "40.473348"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.966829",
+                "latitude": "40.474997"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.967543",
+                "latitude": "40.475627"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.937634",
+                "latitude": "40.51466"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.939232",
+                "latitude": "40.52272"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.938436",
+                "latitude": "40.524773"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.936031",
+                "latitude": "40.525124"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.935111",
+                "latitude": "40.525301"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.93887",
+                "latitude": "40.525406"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.934279",
+                "latitude": "40.525522"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.933362",
+                "latitude": "40.525614"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.932552",
+                "latitude": "40.526243"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.931688",
+                "latitude": "40.527149"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.931155",
+                "latitude": "40.527509"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.931143",
+                "latitude": "40.52773"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.930801",
+                "latitude": "40.528322"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.930534",
+                "latitude": "40.528882"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.929934",
+                "latitude": "40.529371"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.908271",
+                "latitude": "40.531332"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.908102",
+                "latitude": "40.533325"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.906939",
+                "latitude": "40.533655"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.905755",
+                "latitude": "40.534342"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.911881",
+                "latitude": "40.535282"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.927242",
+                "latitude": "40.537826"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.927721",
+                "latitude": "40.538408"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.927466",
+                "latitude": "40.53872"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.927319",
+                "latitude": "40.538776"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.918608",
+                "latitude": "40.539033"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.918357",
+                "latitude": "40.53922"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.92",
+                "latitude": "40.54"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.92678",
+                "latitude": "40.540018"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.926774",
+                "latitude": "40.540312"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.926862",
+                "latitude": "40.540618"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.926719",
+                "latitude": "40.54076"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.92658",
+                "latitude": "40.540927"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.926475",
+                "latitude": "40.541213"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.926564",
+                "latitude": "40.541354"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.926268",
+                "latitude": "40.541631"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.539224",
+                "latitude": "40.579673"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.538416",
+                "latitude": "40.58177"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.526003",
+                "latitude": "40.593228"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.695984",
+                "latitude": "40.610465"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.699275",
+                "latitude": "40.61232"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.701008",
+                "latitude": "40.612685"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.610677",
+                "latitude": "40.616078"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.704611",
+                "latitude": "40.617723"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.688482",
+                "latitude": "40.618733"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.704598",
+                "latitude": "40.620006"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.70586",
+                "latitude": "40.620357"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.688785",
+                "latitude": "40.620793"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.605495",
+                "latitude": "40.620927"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.705621",
+                "latitude": "40.622301"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.705728",
+                "latitude": "40.622516"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-76.085795",
+                "latitude": "40.62343"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.705864",
+                "latitude": "40.623446"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.613112",
+                "latitude": "40.649554"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.293638",
+                "latitude": "40.659443"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.292801",
+                "latitude": "40.659693"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.413542",
+                "latitude": "40.665193"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.413424",
+                "latitude": "40.665194"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.413715",
+                "latitude": "40.665246"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.41361",
+                "latitude": "40.665251"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.41038",
+                "latitude": "40.681258"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.410434",
+                "latitude": "40.682795"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.410784",
+                "latitude": "40.684592"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.399503",
+                "latitude": "40.687"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.821357",
+                "latitude": "40.697834"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.252105",
+                "latitude": "40.707238"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.830445",
+                "latitude": "40.707718"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.831259",
+                "latitude": "40.707753"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.830681",
+                "latitude": "40.707896"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.252393",
+                "latitude": "40.708233"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.829973",
+                "latitude": "40.70846"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.830288",
+                "latitude": "40.708509"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.830491",
+                "latitude": "40.708706"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.830786",
+                "latitude": "40.709083"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.830929",
+                "latitude": "40.709226"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.830639",
+                "latitude": "40.709285"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.830407",
+                "latitude": "40.709425"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.252319",
+                "latitude": "40.709485"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.83148",
+                "latitude": "40.709542"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.830729",
+                "latitude": "40.709987"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.250873",
+                "latitude": "40.710988"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.830923",
+                "latitude": "40.711794"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-116.829338",
+                "latitude": "40.712499"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.209143",
+                "latitude": "40.71278"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.248736",
+                "latitude": "40.71299"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.208777",
+                "latitude": "40.715087"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.208938",
+                "latitude": "40.717546"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.214637",
+                "latitude": "40.719658"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.217606",
+                "latitude": "40.721556"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.217997",
+                "latitude": "40.723118"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.21835",
+                "latitude": "40.723636"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.219009",
+                "latitude": "40.725074"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.219443",
+                "latitude": "40.725929"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.218971",
+                "latitude": "40.726725"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.218937",
+                "latitude": "40.727276"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.220203",
+                "latitude": "40.728163"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.220969",
+                "latitude": "40.728618"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.221555",
+                "latitude": "40.729152"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.224347",
+                "latitude": "40.732182"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.838177",
+                "latitude": "40.736508"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.229455",
+                "latitude": "40.736654"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.854372",
+                "latitude": "40.739864"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.233906",
+                "latitude": "40.741815"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.860714",
+                "latitude": "40.74227"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.842967",
+                "latitude": "40.766912"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.846088",
+                "latitude": "40.777265"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.820252",
+                "latitude": "40.78513"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.117372",
+                "latitude": "40.799528"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.802562",
+                "latitude": "40.806069"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.799711",
+                "latitude": "40.808365"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.799058",
+                "latitude": "40.808984"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.798554",
+                "latitude": "40.809399"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.798245",
+                "latitude": "40.80963"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.797512",
+                "latitude": "40.810011"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.79697",
+                "latitude": "40.810251"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.794385",
+                "latitude": "40.817423"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.79488",
+                "latitude": "40.817588"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.795825",
+                "latitude": "40.81824"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.798142",
+                "latitude": "40.818292"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.799289",
+                "latitude": "40.818583"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.806002",
+                "latitude": "40.819282"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.810268",
+                "latitude": "40.820667"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.534681",
+                "latitude": "40.822756"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.019224",
+                "latitude": "40.849804"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.800033",
+                "latitude": "40.850361"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.617167",
+                "latitude": "40.850729"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.571719",
+                "latitude": "40.853835"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.571956",
+                "latitude": "40.85423"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.571921",
+                "latitude": "40.854366"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.571851",
+                "latitude": "40.854597"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.571825",
+                "latitude": "40.854721"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.571858",
+                "latitude": "40.854916"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.571748",
+                "latitude": "40.855301"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.571674",
+                "latitude": "40.855646"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.571579",
+                "latitude": "40.855942"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.571541",
+                "latitude": "40.856589"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.571387",
+                "latitude": "40.858347"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.605327",
+                "latitude": "40.859471"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.890787",
+                "latitude": "40.860298"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.891289",
+                "latitude": "40.860431"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.020624",
+                "latitude": "40.860738"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.592515",
+                "latitude": "40.878885"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.027643",
+                "latitude": "40.878939"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.921224",
+                "latitude": "40.881691"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.929753",
+                "latitude": "40.882564"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.958301",
+                "latitude": "40.883751"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.602383",
+                "latitude": "40.884532"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.924097",
+                "latitude": "40.884624"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.045995",
+                "latitude": "40.884726"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.046085",
+                "latitude": "40.886217"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.60541",
+                "latitude": "40.889027"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.589763",
+                "latitude": "40.893859"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.585526",
+                "latitude": "40.897838"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.58515",
+                "latitude": "40.900638"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.860219",
+                "latitude": "40.908463"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.482331",
+                "latitude": "40.911343"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.838056",
+                "latitude": "40.911647"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.837498",
+                "latitude": "40.9122"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.838936",
+                "latitude": "40.914553"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.834826",
+                "latitude": "40.914814"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.820014",
+                "latitude": "40.915032"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.837432",
+                "latitude": "40.91546"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.819518",
+                "latitude": "40.92381"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.503511",
+                "latitude": "40.934353"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.201848",
+                "latitude": "40.946333"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.592428",
+                "latitude": "40.994365"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-115.089303",
+                "latitude": "41.023053"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-115.08764",
+                "latitude": "41.023315"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-115.012387",
+                "latitude": "41.087771"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-115.012926",
+                "latitude": "41.089032"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-115.055755",
+                "latitude": "41.092294"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.31415",
+                "latitude": "41.183021"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.31533",
+                "latitude": "41.183185"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.790062",
+                "latitude": "41.195499"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.081341",
+                "latitude": "41.235706"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.08107",
+                "latitude": "41.236396"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.080992",
+                "latitude": "41.236772"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.08092",
+                "latitude": "41.237399"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.153191",
+                "latitude": "41.258479"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.153642",
+                "latitude": "41.258986"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.150499",
+                "latitude": "41.25923"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.153679",
+                "latitude": "41.259284"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.154467",
+                "latitude": "41.260337"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.154543",
+                "latitude": "41.26072"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.141302",
+                "latitude": "41.262929"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.141693",
+                "latitude": "41.262961"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.141859",
+                "latitude": "41.263192"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.142383",
+                "latitude": "41.26334"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.142913",
+                "latitude": "41.263511"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.143002",
+                "latitude": "41.264087"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.156167",
+                "latitude": "41.264653"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.156549",
+                "latitude": "41.265204"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.14664",
+                "latitude": "41.265951"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.156841",
+                "latitude": "41.26597"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.156791",
+                "latitude": "41.266784"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.157593",
+                "latitude": "41.26777"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.307768",
+                "latitude": "41.268181"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.783767",
+                "latitude": "41.342077"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.779541",
+                "latitude": "41.345845"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.775735",
+                "latitude": "41.348725"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.639956",
+                "latitude": "41.42373"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.640383",
+                "latitude": "41.423961"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.640676",
+                "latitude": "41.424189"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.640661",
+                "latitude": "41.424584"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.64077",
+                "latitude": "41.424983"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.640679",
+                "latitude": "41.425014"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.639587",
+                "latitude": "41.425255"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.640836",
+                "latitude": "41.426132"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.538903",
+                "latitude": "41.545738"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.666417",
+                "latitude": "41.582646"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.274618",
+                "latitude": "41.652945"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.274717",
+                "latitude": "41.652948"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.272451",
+                "latitude": "41.655612"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.746029",
+                "latitude": "41.70925"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.746459",
+                "latitude": "41.709664"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.747127",
+                "latitude": "41.709711"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "41.766282",
+                "latitude": "41.766282"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-118.678152",
+                "latitude": "41.76965"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-118.671838",
+                "latitude": "41.771445"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-118.655653",
+                "latitude": "41.783474"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-118.666542",
+                "latitude": "41.783693"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.938111",
+                "latitude": "42.140153"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.945956",
+                "latitude": "42.14433"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.936924",
+                "latitude": "42.150718"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.934186",
+                "latitude": "42.152841"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.920235",
+                "latitude": "42.155078"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.940754",
+                "latitude": "42.156086"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.914055",
+                "latitude": "42.160713"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.908422",
+                "latitude": "42.170533"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.929556",
+                "latitude": "42.174788"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.921743",
+                "latitude": "42.175402"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.921658",
+                "latitude": "42.175517"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.915863",
+                "latitude": "42.175829"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.915789",
+                "latitude": "42.175887"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.915878",
+                "latitude": "42.17606"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.915981",
+                "latitude": "42.176297"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.915883",
+                "latitude": "42.176575"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-119.91396",
+                "latitude": "42.17721"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.177728",
+                "latitude": "42.578343"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.179685",
+                "latitude": "42.57838"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.17864",
+                "latitude": "42.578381"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.178117",
+                "latitude": "42.578402"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.180609",
+                "latitude": "42.578624"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.181295",
+                "latitude": "42.578761"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.095189",
+                "latitude": "42.785573"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.094766",
+                "latitude": "42.785959"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.094536",
+                "latitude": "42.786236"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.09418",
+                "latitude": "42.786467"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.093789",
+                "latitude": "42.786846"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.093468",
+                "latitude": "42.787346"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.092935",
+                "latitude": "42.787745"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.092543",
+                "latitude": "42.788073"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.091395",
+                "latitude": "42.788396"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.090659",
+                "latitude": "42.788929"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.090243",
+                "latitude": "42.789035"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.089944",
+                "latitude": "42.789258"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.089347",
+                "latitude": "42.789602"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.089047",
+                "latitude": "42.790152"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.088773",
+                "latitude": "42.790203"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.08676",
+                "latitude": "42.7906"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.086554",
+                "latitude": "42.790788"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.085121",
+                "latitude": "42.792088"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.084312",
+                "latitude": "42.792509"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.083803",
+                "latitude": "42.792706"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.083227",
+                "latitude": "42.793439"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.082632",
+                "latitude": "42.793663"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.081966",
+                "latitude": "42.794189"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-120.081582",
+                "latitude": "42.794384"
+            }]
+        },
+        {
+            "@type": "Place",
+            "geo": [{
+                "@type": "GeoCoordinates",
+                "longitude": "-118.188868",
+                "latitude": "43.476502"
+            }]
+        }
+    ]
+}

--- a/DataCite2SDO/ExampleOutput/readme.txt
+++ b/DataCite2SDO/ExampleOutput/readme.txt
@@ -1,0 +1,11 @@
+example JSONLD generated from DataCite xml
+
+filenames ending in xx were transformed from xml files obtained from DataCite using links like https://data.datacite.org/application/vnd.datacite.datacite+xml/10.1594/ieda/100577
+
+filenames starting with php were transformed from new DataCite xml files from EarthChem library that will be used to update our DataCite metadata for those resources.
+
+
+Note funding is in an 'isPartOf' key. 
+
+SM Richard
+20180115

--- a/DataCite2SDO/XMLToSchemaOrgDataset-template.xslt
+++ b/DataCite2SDO/XMLToSchemaOrgDataset-template.xslt
@@ -1,0 +1,428 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    exclude-result-prefixes="xs" version="1.0">
+
+    <!-- 
+  Template to build xsl transform to map content from standard xml metadata formats to 
+  Schema.org JSON-LD for @type=Dataset. The design uses a set of 
+  xsl variables and templates to do the mapping from the xml document
+  to the appropriate JSON-LD content. To configure for new metadata
+  scheme, update the code to extract needed information in the appropriate
+  variables and templates.
+  Note that each template has a set of variables as well.
+
+  Note that namespace declarations might need to be added on the root
+   stylesheet element for other metadata schemes. The template includes 
+   root element xpath for ISO19139.
+    
+    
+  Stephen M. Richard
+    2017-01-12
+ -->
+
+    <xsl:output method="text" indent="yes" encoding="UTF-8"/>
+
+    <!-- xpath for the root element in the xml document needs to be 
+     updated in the base template match statement to adapt for other
+     metadata formats. -->
+
+    <xsl:template name="creators">
+        <xsl:param name="creatorList"/>
+        <!-- returns JSON array of schema.org Person objects -->
+        <xsl:text>[</xsl:text>
+        <xsl:for-each select="$creatorList/child::node()">
+            <!-- handle each person in the creatorList -->
+            <xsl:variable name="personID" select="'person ID'"/>
+            <xsl:variable name="personName" select="'person name'"/>
+            <xsl:text>{&#10;
+                "@type": "Person",&#10;
+                "additionalType": "geolink:Person",&#10;</xsl:text>
+            <xsl:text>      "@id": "</xsl:text>
+            <xsl:value-of select="$personID"/>
+            <xsl:text>",&#10;</xsl:text>
+            <xsl:text>      "name": "</xsl:text>
+            <xsl:value-of select="$personName"/>
+            <xsl:text>"&#10;</xsl:text>
+
+            <!-- more content might be available; insert here -->
+
+            <xsl:text>}&#10;</xsl:text>
+        </xsl:for-each>
+        <xsl:text>]</xsl:text>
+    </xsl:template>
+
+    <xsl:template name="distributions">
+        <xsl:param name="distributionList"/>
+        <!-- returns JSON array of schema.org Person objects -->
+        <xsl:text>[</xsl:text>
+        <xsl:for-each select="$distributionList/child::node()">
+            <!-- handle each person in the creatorList -->
+            <xsl:variable name="accessURL" select="'accessURL'"/>
+            <xsl:variable name="distFormat" select="'distFormat'"/>
+            <xsl:variable name="distPublishDate" select="'distPublishDate'"/>
+            <xsl:variable name="distIdentifier" select="'distIdentifier'"/>
+
+            <xsl:text>{&#10;</xsl:text>
+
+            <xsl:if test="$distIdentifier">
+                <xsl:text>      "@id": "</xsl:text>
+                <xsl:value-of select="$distIdentifier"/>
+                <xsl:text>",&#10;</xsl:text>
+            </xsl:if>
+
+            <xsl:text>    "@type": "DataDownload",&#10;    "additionalType": "dcat:distribution",&#10;</xsl:text>
+
+            <xsl:text>      "dcat:accessURL": "</xsl:text>
+            <xsl:value-of select="$accessURL"/>
+            <xsl:text>",&#10;</xsl:text>
+
+            <xsl:text>      "url": "</xsl:text>
+            <xsl:value-of select="$accessURL"/>
+            <xsl:text>",&#10;</xsl:text>
+
+            <xsl:if test="$distFormat">
+                <xsl:text>      "encodingFormat": "</xsl:text>
+                <xsl:value-of select="$distFormat"/>
+                <xsl:text>",&#10;</xsl:text>
+            </xsl:if>
+
+            <xsl:if test="$distPublishDate">
+                <xsl:text>      "datePublished": "</xsl:text>
+                <xsl:value-of select="$distPublishDate"/>
+                <xsl:text>"&#10;</xsl:text>
+            </xsl:if>
+
+            <!-- more content might be available; insert here -->
+
+            <xsl:text>}&#10;</xsl:text>
+        </xsl:for-each>
+        <xsl:text>]</xsl:text>
+    </xsl:template>
+
+    <xsl:template name="identifiers">
+        <xsl:param name="identifierList"/>
+        <!-- returns JSON array of schema.org Person objects -->
+        <xsl:text>[</xsl:text>
+        <xsl:for-each select="$identifierList/child::node()">
+            <!-- handle each person in the creatorList -->
+            <xsl:variable name="idenID" select="'idenID'"/>
+            <xsl:variable name="idenTypeID" select="'idenTypeID'"/>
+            <xsl:variable name="idenURL" select="'idenURL'"/>
+            <xsl:variable name="idenValue" select="'idenValue'"/>
+
+            <xsl:text>{&#10;</xsl:text>
+
+            <xsl:if test="$idenID">
+                <xsl:text>      "@id": "</xsl:text>
+                <xsl:value-of select="$idenID"/>
+                <xsl:text>",&#10;</xsl:text>
+            </xsl:if>
+
+            <xsl:text>      "@type": "PropertyValue",&#10;      "additionalType": [&#10;
+                           "geolink:Identifier",&#10;
+        "datacite:Identifier"&#10;
+      ],&#10;</xsl:text>
+
+            <xsl:if test="$idenTypeID">
+                <xsl:text>      "propertyID": "</xsl:text>
+                <xsl:value-of select="$idenTypeID"/>
+                <xsl:text>",&#10;</xsl:text>
+            </xsl:if>
+
+            <xsl:if test="$idenURL">
+                <xsl:text>      "url": "</xsl:text>
+                <xsl:value-of select="$idenURL"/>
+                <xsl:text>",&#10;</xsl:text>
+            </xsl:if>
+
+            <xsl:if test="$idenValue">
+                <xsl:text>      "value": "</xsl:text>
+                <xsl:value-of select="$idenValue"/>
+                <xsl:text>"&#10;</xsl:text>
+            </xsl:if>
+
+            <!-- more content might be available; insert here -->
+
+            <xsl:text>}&#10;</xsl:text>
+        </xsl:for-each>
+        <xsl:text>]</xsl:text>
+    </xsl:template>
+
+    <xsl:template name="keywords">
+        <xsl:param name="keywordList"/>
+        <xsl:text>[</xsl:text>
+        <xsl:for-each select="$keywordList/child::node()">
+            <!-- extract one or more keywords from each keywordList element -->
+            <xsl:variable name="keyword" select="'keyword'"/>
+            <xsl:value-of select="$keyword"/>
+            <xsl:text>,&#10;</xsl:text>
+        </xsl:for-each>
+
+        <xsl:text>]</xsl:text>
+    </xsl:template>
+
+    <xsl:template name="spatialCoverage">
+        <xsl:param name="extentList"/>
+        <!-- returns JSON array of schema.org Person objects -->
+        <xsl:text>[</xsl:text>
+        <xsl:for-each select="$extentList/child::node()">
+            <!-- handle each person in the creatorList -->
+            <xsl:variable name="CRSvalue" select="'CRSvalue'"/>
+            <xsl:variable name="geoShapeBox" select="'geoShapeBox'"/>
+            <xsl:variable name="geoShapePolygon" select="'geoShapePolygon'"/>
+            <xsl:variable name="placeName" select="'placeName'"/>
+
+            <xsl:text>{&#10;</xsl:text>
+            <xsl:text>"@type": "Place",&#10;</xsl:text>
+    <!-- if the Spatial referenc system is available... -->
+            <xsl:if test="$CRSvalue">
+                <xsl:text>     "additionalProperty": [{&#10;
+            "@type": "PropertyValue",&#10;
+            "alternateName": "CRS",&#10;
+            "name": "Coordinate Reference System", &#10;</xsl:text>
+                <xsl:text>"value": "</xsl:text>
+                <xsl:value-of select="$CRSvalue"/>
+                <xsl:text>"&#10;}],&#10;</xsl:text>
+            </xsl:if>
+   <!-- if there's a place name  -->
+            <xsl:if test="$placeName">
+                <xsl:text>      "name": "</xsl:text>
+                <xsl:value-of select="$placeName"/>
+                <xsl:text>",&#10;</xsl:text>
+            </xsl:if>
+
+ <!-- if there are coordinates... -->
+<xsl:if test="string-length($geoShapePolygon) + string-length($geoShapeBox) > 0">
+    <xsl:text>      "geo":{</xsl:text>
+    <xsl:text> 			"@type": "GeoShape",&#10;</xsl:text>
+                <xsl:if test="$geoShapeBox">
+                    <xsl:text>      "box": "</xsl:text>
+                    <xsl:value-of select="$geoShapeBox"/>
+                    <xsl:text>",&#10;</xsl:text>
+                </xsl:if>
+
+                <xsl:if test="$geoShapePolygon">
+                    <xsl:text>      "polygon": "</xsl:text>
+                    <xsl:value-of select="$geoShapePolygon"/>
+                    <xsl:text>"&#10;</xsl:text>
+                </xsl:if>
+    <xsl:text>}&#10;</xsl:text>
+</xsl:if>
+            <!-- more content might be available; insert here -->
+
+            <xsl:text>}&#10;</xsl:text>
+        </xsl:for-each>
+        <xsl:text>],&#10;</xsl:text>
+    </xsl:template>
+
+    <xsl:template name="variableMeasured">
+        <xsl:param name="variableList"/>
+        <!-- returns JSON array of schema.org Person objects -->
+        
+        <xsl:text>[</xsl:text>
+        <xsl:for-each select="$variableList/child::node()">
+        <!-- handle each person in the creatorList -->
+        <xsl:variable name="variableID" select="'variableID'"/>
+        <xsl:variable name="varDescription" select="'distFormat'"/>
+        <xsl:variable name="varUnitsText" select="'distPublishDate'"/>
+        <xsl:variable name="varURL" select="'distIdentifier'"/>
+        <xsl:variable name="varName" select="'distIdentifier'"/>
+        <xsl:variable name="varValue" select="'distIdentifier'"/>
+            
+        <xsl:text>{&#10;</xsl:text>
+        
+        <xsl:if test="$variableID   ">
+            <xsl:text>      "@id": "</xsl:text>
+            <xsl:value-of select="$variableID"/>
+            <xsl:text>",&#10;</xsl:text>
+        </xsl:if>
+        
+        <xsl:text>    "@type": "PropertyValue",&#10;    "additionalType": "earthcollab:Parameter",&#10;</xsl:text>
+        
+        <xsl:if test="$varDescription">       
+        <xsl:text>      "description": "</xsl:text>
+        <xsl:value-of select="$varDescription"/>
+        <xsl:text>",&#10;</xsl:text>
+        </xsl:if>
+            
+        <xsl:text>      "unitText": "</xsl:text>
+        <xsl:value-of select="$varUnitsText"/>
+        <xsl:text>",&#10;</xsl:text>
+        
+        <xsl:if test="$varURL">
+            <xsl:text>      "url": "</xsl:text>
+            <xsl:value-of select="$varURL"/>
+            <xsl:text>",&#10;</xsl:text>
+        </xsl:if>
+        
+        <xsl:if test="$varValue">
+            <xsl:text>      "value": "</xsl:text>
+            <xsl:value-of select="$varValue"/>
+            <xsl:text>"&#10;</xsl:text>
+        </xsl:if>
+        
+        <!-- more content might be available; insert here -->
+        
+        <xsl:text>}&#10;</xsl:text>
+        </xsl:for-each>
+        
+        <xsl:text>],&#10;</xsl:text>
+    </xsl:template>
+
+
+    <xsl:template match="//gmd:MD_Metadata">
+        <!-- Define variables for content elements -->
+        <xsl:variable name="additionalContexts">
+            <xsl:text>"datacite": "http://purl.org/spar/datacite/",&#10;
+                "earthcollab": "https://library.ucar.edu/earthcollab/schema#",&#10;
+                "geolink": "http://schema.geolink.org/1.0/base/main#",&#10;
+                "vivo": "http://vivoweb.org/ontology/core#",&#10;
+                "dcat":"http://www.w3.org/ns/dcat#"&#10;
+                </xsl:text>
+        </xsl:variable>
+        <xsl:variable name="DOIuri" select="'not defined yet'"/>
+        <xsl:variable name="DOIvalue" select="'not defined yet'"/>
+        <xsl:variable name="name" select="'not defined yet'"/>
+        <xsl:variable name="alternateName" select="'not defined yet'"/>
+        <xsl:variable name="citation" select="'not defined yet'"/>
+        <xsl:variable name="datePublished" select="'not defined yet'"/>
+        <xsl:variable name="description" select="'not defined yet'"/>
+        <xsl:variable name="DataCatalogName" select="'not defined yet'"/>
+        <xsl:variable name="DataCatalogURL" select="'not defined yet'"/>
+        <xsl:variable name="awardID" select="'not defined yet'"/>
+        <xsl:variable name="awardDescription" select="'not defined yet'"/>
+        <xsl:variable name="awardname" select="'not defined yet'"/>
+        <xsl:variable name="awardURL" select="'not defined yet'"/>
+        <xsl:variable name="license" select="'not defined yet'"/>
+
+
+        <!-- default values to use in lieu of extracted provider; customize
+      logic in format/profile-specific implementations to decide which to use-->
+        <xsl:variable name="providerDefault" select="'not defined yet'"/>
+        <xsl:variable name="publisherDefault" select="'not defined yet'"/>
+        <xsl:variable name="publshingPrinciplesDefault" select="'not defined yet'"/>
+        <xsl:variable name="provider" select="''"/>
+        <xsl:variable name="publisher" select="''"/>
+        <xsl:variable name="publshingPrinciples" select="''"/>
+
+        <!-- construct the JSON with xsl text elements. &#10; is carriage return -->
+        <xsl:text>{&#10;  "@context": {&#10;</xsl:text>
+        <xsl:text> "@vocab": "http://schema.org/",&#10;</xsl:text>
+
+        <xsl:text>  },&#10; </xsl:text>
+
+        <xsl:text>"@id": "</xsl:text>
+        <xsl:value-of select="$DOIuri"/>
+        <xsl:text>",&#10;</xsl:text>
+        <xsl:text>  "@type": "Dataset",&#10;</xsl:text>
+        <xsl:text>  "additionalType": [&#10;    "geolink:Dataset",&#10;    "vivo:Dataset"&#10;  ],&#10;</xsl:text>
+
+        <xsl:text>  "name": "</xsl:text>
+        <xsl:value-of select="$name"/>
+        <xsl:text>",&#10;</xsl:text>
+
+        <xsl:text>  "alternateName": "</xsl:text>
+        <xsl:value-of select="$alternateName"/>
+        <xsl:text>",&#10;</xsl:text>
+
+        <xsl:text>  "citation": "</xsl:text>
+        <xsl:value-of select="$citation"/>
+        <xsl:text>",&#10;</xsl:text>
+
+        <xsl:text>  "creator":&#10;</xsl:text>
+        <xsl:call-template name="creators"/>
+        <xsl:text>,&#10;</xsl:text>
+
+        <xsl:text>  "datePublished": "</xsl:text>
+        <xsl:value-of select="$datePublished"/>
+        <xsl:text>",&#10;</xsl:text>
+
+        <xsl:text>  "description": "</xsl:text>
+        <xsl:value-of select="$description"/>
+        <xsl:text>",&#10;</xsl:text>
+
+        <xsl:text>  "distribution": [&#10;</xsl:text>
+        <xsl:call-template name="distributions"/>
+        <xsl:text>  ],&#10;</xsl:text>
+
+        <xsl:text>  "identifier": [&#10;</xsl:text>
+        <xsl:call-template name="identifiers"/>
+        <xsl:text>  ],&#10;</xsl:text>
+
+
+        <xsl:text>  "includedInDataCatalog": {&#10; 
+    "@type":"DataCatalog",&#10;</xsl:text>
+        <xsl:text>  "name":"</xsl:text>
+        <xsl:value-of select="$DataCatalogName"/>
+        <xsl:text>",&#10;</xsl:text>
+        <xsl:text>  "url": "</xsl:text>
+        <xsl:value-of select="$DataCatalogURL"/>
+        <xsl:text>",&#10;</xsl:text>
+        <xsl:text>},&#10;</xsl:text>
+
+        <!-- put award information in isPartOf...  -->
+        <xsl:text>  "isPartOf": {&#10;</xsl:text>
+        <xsl:text>     "@id":"</xsl:text>
+        <xsl:value-of select="$awardID"/>
+        <xsl:text>",&#10;</xsl:text>
+        <xsl:text>     "@type": "CreativeWork",&#10;
+    "additionalType": "earthcollab:Project",&#10;</xsl:text>
+        <xsl:text>     "description": "</xsl:text>
+        <xsl:value-of select="$awardDescription"/>
+        <xsl:text>",&#10;</xsl:text>
+        <xsl:text>     "name": "</xsl:text>
+        <xsl:value-of select="$awardname"/>
+        <xsl:text>",&#10;</xsl:text>
+        <xsl:text>     "url": "</xsl:text>
+        <xsl:value-of select="$awardURL"/>
+        <xsl:text>",&#10;</xsl:text>
+        <xsl:text>},&#10;</xsl:text>
+
+        <xsl:text>  "keywords": "</xsl:text>
+        <xsl:call-template name="keywords"/>
+        <xsl:text>",&#10;</xsl:text>
+
+        <xsl:text>  "license": "</xsl:text>
+        <xsl:value-of select="$license"/>
+        <xsl:text>",&#10;</xsl:text>
+
+        <!--  "measurementTechnique": ["Electron Microprobe"], aspiration...-->
+
+        <xsl:text>  "provider": </xsl:text>
+        <xsl:choose>
+            <xsl:when test="$provider">
+                <xsl:value-of select="$provider"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$providerDefault"/>
+            </xsl:otherwise>
+        </xsl:choose>
+        <xsl:text>,&#10;</xsl:text>
+
+        <xsl:text>  "publisher": </xsl:text>
+        <xsl:choose>
+            <xsl:when test="$publisher">
+                <xsl:value-of select="$publisher"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$publisherDefault"/>
+            </xsl:otherwise>
+        </xsl:choose>
+        <xsl:text>,&#10;</xsl:text>
+
+        <xsl:text>  "spatialCoverage": </xsl:text>
+        <xsl:call-template name="spatialCoverage">
+            <xsl:with-param name="geoLocation"/>
+        </xsl:call-template>
+        <xsl:text>,&#10;</xsl:text>
+
+        <xsl:text>  "variableMeasured": </xsl:text>
+        <xsl:call-template name="variableMeasured">
+            <xsl:with-param name="variables"/>
+        </xsl:call-template>
+        <xsl:text>,&#10;</xsl:text>
+
+    </xsl:template>
+</xsl:stylesheet>

--- a/DataCite2SDO/readme.txt
+++ b/DataCite2SDO/readme.txt
@@ -1,0 +1,19 @@
+This directory contains XML transform modules to create schema.org JSON-LD to insert in web pages for Datasets.
+
+ XMLToSchemaOrgDataset-template.xslt is a template file that can be used as a starting point to create JSON-LD from an XML metdata format. 
+ 
+ DataCiteToSchemaOrgDataset.xslt is a transform to create schema.org JSON-LD from dataCite XML. The module will work with DataCite v2, v3 and v4.  Funding references are places in an 'isPartOf' key, pending community convergence on how to represent acknowledgment for funding support for creation of a dataset. The transform duplicates JSON-LD produced from the DataCite service (e.g. https://data.datacite.org/application/vnd.schemaorg.ld+json/10.1594/ieda/100577), results can be compared with the files in the examples directory.
+ 
+ Differences with DataCite generated schema.org markup:
+ 
+ the transform includes spatialCoverage content if present
+ the transform puts keywords in as an array of strings, the subjectScheme attribute is not transferred to the JSON-LD
+ Transform does not include a 'schemaVersion' element; guidance on that property suggests the schema would be the content schema for the resoruce documented by the metadata, not the metadata. 
+ The provider organization is the same as the publisher (not DataCite as in the DataCite versions.)
+ The transform includes some other additionalTypes.
+ The transform generates a distribution object for the dataset landing page; if http alternate identifiers are included, these are also represented as distributions. 
+ Non http alternate identifiers are included in an identifiers key. 
+ 
+ 
+ SM Richard
+ 20180115

--- a/examples/EarthChem952-1.jsonld
+++ b/examples/EarthChem952-1.jsonld
@@ -1,163 +1,173 @@
 {
-	"@context": {
-		"@vocab": "http://schema.org/",
-		"datacite": "http://purl.org/spar/datacite/",
-		"earthcollab": "https://library.ucar.edu/earthcollab/schema#",
-		"geolink": "http://schema.geolink.org/1.0/base/main#",
-		"vivo": "http://vivoweb.org/ontology/core#",
-		"dcat": "http://www.w3.org/ns/dcat#"
-	},
-	"@id": "doi:10.1594/IEDA/100599",
-	"@type": "Dataset",
-	"additionalType": ["geolink:Dataset",
-	"vivo:Dataset"],
-	"alternateName": "Plagioclase data from the Hicks Butte Inlier, central Cascades, Washington, USA",
-	"citation": "MacDonald, James H. (2016): Plagioclase data from the Hicks Butte Inlier, central Cascades, Washington, USA. EarthChem Library. http://dx.doi.org/10.1594/IEDA/100599",
-	"creator": [{
-		"@id": "https://orcid.org/0000-0001-7576-5575",
-		"@type": "Person",
-		"additionalType": "geolink:Person",
-		"name": "MacDonald, James H."
-	}],
-	"datePublished": "2016-06-15",
-	"description": "In this data set is plagioclase and amphibole data that was part of Thompson et al. (2015) Geological Society of America abstract. This data was generated at the Florida Center for Analytical Electron Microscopy, and was funded by NSF grant DUE 1323354.",
-	"distribution":[
-	 {
-		"@type": "DataDownload",
-		"additionalType": ["dcat:distribution"],
-		"dcat:accessURL": "http://grl.geoinfogeochem.org/downloadFeedback.php?id=952",
-		"datePublished": "2016-06-15",
-		"thumbnailUrl": "null",
-		"encodingFormat": "application/vnd.ms-excel",
-		"inLanguage": "en-US"
-	}
-	],
-	"identifier": [{
-		"@id": "doi:10.1594/IEDA/100599",
-		"@type": "PropertyValue",
-		"additionalType": ["geolink:Identifier",
-		"datacite:Identifier"],
-		"propertyID": "datacite:doi",
-		"url": "http://dx.doi.org/10.1594/IEDA/100599",
-		"value": "10.1594/IEDA/100599"
-	}],
-	"includedInDataCatalog": {
-		"@type": "DataCatalog",
-		"name": "Earthchem Library",
-		"url": "http://www.earthchem.org/library/search"
-	},
-	"isPartOf": {
-		"@id": "https://nsf.gov/awardsearch/showAward?AWD_ID=1323354",
-		"@type": "CreativeWork",
-		"additionalType": "earthcollab:Project",
-		"description": "This collaborative project is examining the remote operation of analytical instruments, specifically a scanning-electron microscope and electron microprobe analyzer housed at Florida International University (FIU), to facilitate inquiry-based approaches to learning in undergraduate geoscience courses. The effectiveness of remote instrument use is being assessed across different course levels and audiences at four diverse institutions: FIU, Valencia Community College, Florida Gulf Coast University, and the University of South Florida. Faculty at each institution are adapting instrument use to their courses and students, and using common methods to assess learning gains and changes in students' attitudes along a novice-to-expert trajectory. Instrument use and learning assessment at the four partnering institutions is being supplemented by national-level outreach to engage further partners, using hands-on workshops and follow-on individual training and consultation for faculty who commit to pilot use in their own courses. \n The intellectual merit of the project lies in its well-formulated plan to leverage fixed-location, high-end analytical instruments to enable authentic research and inquiry within the undergraduate curriculum at remote institutions. The embedded educational research addresses important questions of a) how much and what type(s) of remote instrument-aided inquiry enable targeted student-learning outcomes, b) what factors determine effectiveness as institution type, curricular level, and student audiences vary, and c) what challenges exist for widespread propagation of the approach and how might these be overcome. Broader impacts of the project include a) the production of insights and practices that promote remote use of research-grade analytical instrumentation at multiple levels of the undergraduate curriculum, providing a model that could be used at other research centers to enable heretofore inaccessible analytical capabilities at a wide range of undergraduate institutions, b) engagement of a diverse range of students (from seniors in majors' classes to first-year non-majors in introductory classes) and institutions (from research universities to community colleges) in authentic research, a high-impact practice for retaining students in STEM disciplines, and c) professional development for faculty at the partnering institutions and beyond, as well as for a postdoctoral scholar and graduate student engaged in discipline-based educational research.",
-		"name": "Collaborative Project: Expanding the Use of Remote Electron Microscopy in the Classroom to Transform Undergraduate Geoscience Education",
-		"url": "https://nsf.gov/awardsearch/showAward?AWD_ID=1323354"
-	},
-	"keywords": ["Hicks Butte complex",
-	"feldspar",
-	"Jurassic",
-	"plagioclase",
-	"dacite",
-	"tonalite",
-	"rhyolite"],
-	"license": "http://creativecommons.org/licenses/by-sa-nc/3.0/",
-	"measurementTechnique": ["Electron Microprobe"],
-	"name": "Plagioclase data from the Hicks Butte Inlier, central Cascades, Washington, USA",
-	"provider": {
-		"@type": "Organization",
-		"@id": "https://www.iedadata.org/",
-		"name": "Interdisciplinary Earth Data Alliance (IEDA)"
-	},
-	"publisher": {
-		"@type": "Organization",
-		"@id": "https://www.iedadata.org/",
-		"name": "Interdisciplinary Earth Data Alliance (IEDA)",
-		"url": "https://www.iedadata.org/",
-		"description": "The IEDA data facility mission is to support, sustain, and advance the geosciences by providing data services for observational geoscience data from the Ocean, Earth, and Polar Sciences. IEDA systems serve as primary community data collections for global geochemistry and marine geoscience research and support the preservation, discovery, retrieval, and analysis of a wide range of observational field and analytical data types. Our tools and services are designed to facilitate data discovery and reuse for focused disciplinary research and to support interdisciplinary research and data integration.",
-		"logo": {
-			"@type": "ImageObject",
-			"url": ""
-		},
-		"contactPoint": {
-			"@type": "ContactPoint",
-			"name": "Kerstin Lehnert",
-			"email": "lehnert@ldeo.columbia.edu",
-			"url": "http://orcid.org/0000-0001-7036-1977",
-			"contactType": "Director"
-		},
-		"funder": {
-			"@type": "Organization",
-			"@id": "http://dx.doi.org/10.13039/100000085",
-			"legalName": "Directorate for Geosciences",
-			"alternateName": "NSF-GEO",
-			"url": "http://www.nsf.gov",
-			"parentOrganization": {
-				"@type": "Organization",
-				"@id": "http://dx.doi.org/10.13039/100000001",
-				"legalName": "National Science Foundation",
-				"alternateName": "NSF",
-				"url": "http://www.nsf.gov"
-			}
-		},
-		"parentOrganization": {
-			"@type": "Organization",
-			"@id": "https://viaf.org/viaf/142992181/",
-			"name": "Lamont-Doherty Earth Observatory",
-			"url": "http://www.ldeo.columbia.edu/",
-			"address": {
-				"@type": "PostalAddress",
-				"streetAddress": "61 Route 9W",
-				"addressLocality": "Palisades",
-				"addressRegion": "NY",
-				"postalCode": "10964-1000",
-				"addressCountry": "USA"
-			},
-			"parentOrganization": {
-				"@type": "Organization",
-				"@id": "https://viaf.org/viaf/156836332/",
-				"legalName": "Columbia University",
-				"url": "http://www.columbia.edu/"
-			}
-		},
-		"publishingPrinciples": {
-			"@id": "http://creativecommons.org/licenses/by-nc-sa/3.0/us/",
-			"@type": "DigitalDocument",
-			"additionalType": "gdx:Protocol-License",
-			"name": "Dataset Usage License",
-			"description": "Creative Commons Attribution-NonCommercial-Share Alike 3.0 United States [CC BY-NC-SA 3.0]",
-			"url": "https://creativecommons.org/licenses/by-nc-sa/3.0/us/"
-		}
-	},
-	"spatialCoverage": [{
-		"@type": "Place",
-		"additionalProperty": [{
-			"@type": "PropertyValue",
-			"alternateName": "CRS",
-			"name": "Coordinate Reference System",
-			"value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
-		}],
-		"geo": {
-			"@type": "GeoShape",
-			"box": "-149.8727,-17.45 -64.6353,34.407",
-			"polygon": "-149.8727,-17.45 -149.8727,34.407 -64.6353,34.407 -64.6353,-17.45 -149.8727,-17.45"
-		}
-	}],
-	"variableMeasured": [{
-		"@id": "https://www.bco-dmo.org/dataset-parameter/665785",
-		"@type": "PropertyValue",
-		"additionalType": "earthcollab:Parameter",
-		"description": "place holder",
-		"unitText": "unitless",
-		"url": "",
-		"value": "",
-		"valueReference": {
-			"@id": "...",
-			"@type": "PropertyValue",
-			"description": "...",
-			"unitText": "text",
-			"url": "...",
-			"value": ".."
-		}
-	}]
+    "@context": {
+        "@vocab": "http://schema.org/",
+        "datacite": "http://purl.org/spar/datacite/",
+        "earthcollab": "https://library.ucar.edu/earthcollab/schema#",
+        "geolink": "http://schema.geolink.org/1.0/base/main#",
+        "vivo": "http://vivoweb.org/ontology/core#",
+        "dcat": "http://www.w3.org/ns/dcat#"
+    },
+    "@id": "doi:10.1594/IEDA/100599",
+    "@type": "Dataset",
+    "additionalType": [
+        "geolink:Dataset",
+        "vivo:Dataset"
+    ],
+    "alternateName": "Plagioclase data from the Hicks Butte Inlier, central Cascades, Washington, USA",
+    "citation": "MacDonald, James H. (2016): Plagioclase data from the Hicks Butte Inlier, central Cascades, Washington, USA. EarthChem Library. http://dx.doi.org/10.1594/IEDA/100599",
+    "creator": [{
+        "@id": "https://orcid.org/0000-0001-7576-5575",
+        "@type": "Person",
+        "additionalType": "geolink:Person",
+        "name": "MacDonald, James H."
+    }],
+    "datePublished": "2016-06-15",
+    "description": "In this data set is plagioclase and amphibole data that was part of Thompson et al. (2015) Geological Society of America abstract. This data was generated at the Florida Center for Analytical Electron Microscopy, and was funded by NSF grant DUE 1323354.",
+    "distribution": [{
+        "@type": "DataDownload",
+        "additionalType": ["dcat:distribution"],
+        "dcat:accessURL": "http://grl.geoinfogeochem.org/downloadFeedback.php?id=952",
+        "datePublished": "2016-06-15",
+        "thumbnailUrl": "null",
+        "encodingFormat": "application/vnd.ms-excel",
+        "inLanguage": "en-US"
+    }],
+    "identifier": [{
+        "@id": "doi:10.1594/IEDA/100599",
+        "@type": "PropertyValue",
+        "additionalType": [
+            "geolink:Identifier",
+            "datacite:Identifier"
+        ],
+        "propertyID": "datacite:doi",
+        "url": "http://dx.doi.org/10.1594/IEDA/100599",
+        "value": "10.1594/IEDA/100599"
+    }],
+    "includedInDataCatalog": {
+        "@type": "DataCatalog",
+        "name": "Earthchem Library",
+        "url": "http://www.earthchem.org/library/search"
+    },
+    "isPartOf": {
+        "@id": "https://nsf.gov/awardsearch/showAward?AWD_ID=1323354",
+        "@type": "CreativeWork",
+        "additionalType": "earthcollab:Project",
+        "description": "This collaborative project is examining the remote operation of analytical instruments, specifically a scanning-electron microscope and electron microprobe analyzer housed at Florida International University (FIU), to facilitate inquiry-based approaches to learning in undergraduate geoscience courses. The effectiveness of remote instrument use is being assessed across different course levels and audiences at four diverse institutions: FIU, Valencia Community College, Florida Gulf Coast University, and the University of South Florida. Faculty at each institution are adapting instrument use to their courses and students, and using common methods to assess learning gains and changes in students' attitudes along a novice-to-expert trajectory. Instrument use and learning assessment at the four partnering institutions is being supplemented by national-level outreach to engage further partners, using hands-on workshops and follow-on individual training and consultation for faculty who commit to pilot use in their own courses. \n The intellectual merit of the project lies in its well-formulated plan to leverage fixed-location, high-end analytical instruments to enable authentic research and inquiry within the undergraduate curriculum at remote institutions. The embedded educational research addresses important questions of a) how much and what type(s) of remote instrument-aided inquiry enable targeted student-learning outcomes, b) what factors determine effectiveness as institution type, curricular level, and student audiences vary, and c) what challenges exist for widespread propagation of the approach and how might these be overcome. Broader impacts of the project include a) the production of insights and practices that promote remote use of research-grade analytical instrumentation at multiple levels of the undergraduate curriculum, providing a model that could be used at other research centers to enable heretofore inaccessible analytical capabilities at a wide range of undergraduate institutions, b) engagement of a diverse range of students (from seniors in majors' classes to first-year non-majors in introductory classes) and institutions (from research universities to community colleges) in authentic research, a high-impact practice for retaining students in STEM disciplines, and c) professional development for faculty at the partnering institutions and beyond, as well as for a postdoctoral scholar and graduate student engaged in discipline-based educational research.",
+        "name": "Collaborative Project: Expanding the Use of Remote Electron Microscopy in the Classroom to Transform Undergraduate Geoscience Education",
+        "url": "https://nsf.gov/awardsearch/showAward?AWD_ID=1323354"
+    },
+    "keywords": [
+        "Hicks Butte complex",
+        "feldspar",
+        "Jurassic",
+        "plagioclase",
+        "dacite",
+        "tonalite",
+        "rhyolite"
+    ],
+    "license": "http://creativecommons.org/licenses/by-sa-nc/3.0/",
+    "measurementTechnique": ["Electron Microprobe"],
+    "name": "Plagioclase data from the Hicks Butte Inlier, central Cascades, Washington, USA",
+    "provider": {
+        "@type": "Organization",
+        "@id": "https://www.iedadata.org/",
+        "name": "Interdisciplinary Earth Data Alliance (IEDA)"
+    },
+    "publisher": {
+        "@type": "Organization",
+        "@id": "https://www.iedadata.org/",
+        "name": "Interdisciplinary Earth Data Alliance (IEDA)",
+        "url": "https://www.iedadata.org/",
+        "description": "The IEDA data facility mission is to support, sustain, and advance the geosciences by providing data services for observational geoscience data from the Ocean, Earth, and Polar Sciences. IEDA systems serve as primary community data collections for global geochemistry and marine geoscience research and support the preservation, discovery, retrieval, and analysis of a wide range of observational field and analytical data types. Our tools and services are designed to facilitate data discovery and reuse for focused disciplinary research and to support interdisciplinary research and data integration.",
+        "logo": {
+            "@type": "ImageObject",
+            "url": ""
+        },
+        "contactPoint": {
+            "@type": "ContactPoint",
+            "name": "Kerstin Lehnert",
+            "email": "lehnert@ldeo.columbia.edu",
+            "url": "http://orcid.org/0000-0001-7036-1977",
+            "contactType": "Director"
+        },
+        "parentOrganization": {
+            "@type": "Organization",
+            "@id": "https://viaf.org/viaf/142992181/",
+            "name": "Lamont-Doherty Earth Observatory",
+            "url": "http://www.ldeo.columbia.edu/",
+            "address": {
+                "@type": "PostalAddress",
+                "streetAddress": "61 Route 9W",
+                "addressLocality": "Palisades",
+                "addressRegion": "NY",
+                "postalCode": "10964-1000",
+                "addressCountry": "USA"
+            },
+            "parentOrganization": {
+                "@type": "Organization",
+                "@id": "https://viaf.org/viaf/156836332/",
+                "legalName": "Columbia University",
+                "url": "http://www.columbia.edu/"
+            }
+        },
+        "funder": {
+            "@type": "Organization",
+            "@id": "http://dx.doi.org/10.13039/100000085",
+            "legalName": "Directorate for Geosciences",
+            "alternateName": "NSF-GEO",
+            "url": "http://www.nsf.gov",
+            "parentOrganization": {
+                "@type": "Organization",
+                "@id": "http://dx.doi.org/10.13039/100000001",
+                "legalName": "National Science Foundation",
+                "alternateName": "NSF",
+                "url": "http://www.nsf.gov"
+            }
+        },
+        "publishingPrinciples": {
+            "@id": "http://creativecommons.org/licenses/by-nc-sa/3.0/us/",
+            "@type": "DigitalDocument",
+            "additionalType": "gdx:Protocol-License",
+            "name": "Dataset Usage License",
+            "description": "Creative Commons Attribution-NonCommercial-Share Alike 3.0 United States [CC BY-NC-SA 3.0]",
+            "url": "https://creativecommons.org/licenses/by-nc-sa/3.0/us/"
+        }
+    },
+    "spatialCoverage": [{
+        "@type": "Place",
+        "additionalProperty": [{
+            "@type": "PropertyValue",
+            "alternateName": "CRS",
+            "name": "Coordinate Reference System",
+            "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }],
+        "geo": [
+        {
+            "@type": "GeoShape",
+            "box": "-149.8727,-17.45 -64.6353,34.407",
+            "polygon": "-149.8727,-17.45 -149.8727,34.407 -64.6353,34.407 -64.6353,-17.45 -149.8727,-17.45",
+            "circle":"-149.8727,-17.45 100"
+        },
+        {
+            
+        }
+        ]
+    }],
+    "variableMeasured": [{
+        "@id": "https://www.bco-dmo.org/dataset-parameter/665785",
+        "@type": "PropertyValue",
+        "additionalType": "earthcollab:Parameter",
+        "description": "place holder",
+        "unitText": "unitless",
+        "url": "",
+        "value": "",
+        "valueReference": {
+            "@id": "...",
+            "@type": "PropertyValue",
+            "description": "...",
+            "unitText": "text",
+            "url": "...",
+            "value": ".."
+        }
+    }]
 }

--- a/examples/EarthChem952-1.jsonld
+++ b/examples/EarthChem952-1.jsonld
@@ -1,167 +1,163 @@
 {
-  "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/",
-    "earthcollab": "https://library.ucar.edu/earthcollab/schema#",
-    "geolink": "http://schema.geolink.org/1.0/base/main#",
-    "vivo": "http://vivoweb.org/ontology/core#",
-    "dcat":"http://www.w3.org/ns/dcat#"
-  },
-  "@id": "doi:10.1594/IEDA/100599",
-  "@type": "Dataset",
-  "additionalType": [
-    "geolink:Dataset",
-    "vivo:Dataset"
-  ],
-  "alternateName": "Plagioclase data from the Hicks Butte Inlier, central Cascades, Washington, USA",
-  "citation": "MacDonald, James H. (2016): Plagioclase data from the Hicks Butte Inlier, central Cascades, Washington, USA. EarthChem Library. http://dx.doi.org/10.1594/IEDA/100599",
-  "creator": [
-    {
-      "@id": "https://orcid.org/0000-0001-7576-5575",
-      "@type": "Person",
-      "additionalType": "geolink:Person",
-      "name": "MacDonald, James H."
-      }
-  ],
-  "datePublished": "2016-06-15",
-  "description": "In this data set is plagioclase and amphibole data that was part of Thompson et al. (2015) Geological Society of America abstract. This data was generated at the Florida Center for Analytical Electron Microscopy, and was funded by NSF grant DUE 1323354.",
-  "distribution": {
-    "@type": "DataDownload",
-    "additionalType": ["dcat:distribution"],
-    "dcat:accessURL": "http://grl.geoinfogeochem.org/downloadFeedback.php?id=952",
-    "datePublished": "2016-06-15",
-    "thumbnailUrl":"null",
-    "encodingFormat": "application/vnd.ms-excel",
-    "inLanguage": "en-US"
-  },
-  "identifier": [
-    {
-      "@id": "doi:10.1594/IEDA/100599",
-      "@type": "PropertyValue",
-      "additionalType": [
-        "geolink:Identifier",
-        "datacite:Identifier"
-      ],
-      "propertyID": "datacite:doi",
-      "url": "http://dx.doi.org/10.1594/IEDA/100599",
-      "value": "10.1594/IEDA/100599"
-    }
-  ],
-  "includedInDataCatalog": { 
-    "@type":"DataCatalog",
-    "name":"Earthchem Library",
-    "url": "http://www.earthchem.org/library/search"
-  },
-  "isPartOf": { 
-    "@id": "https://nsf.gov/awardsearch/showAward?AWD_ID=1323354",
-    "@type": "CreativeWork",
-    "additionalType": "earthcollab:Project",
-    "description": "This collaborative project is examining the remote operation of analytical instruments, specifically a scanning-electron microscope and electron microprobe analyzer housed at Florida International University (FIU), to facilitate inquiry-based approaches to learning in undergraduate geoscience courses. The effectiveness of remote instrument use is being assessed across different course levels and audiences at four diverse institutions: FIU, Valencia Community College, Florida Gulf Coast University, and the University of South Florida. Faculty at each institution are adapting instrument use to their courses and students, and using common methods to assess learning gains and changes in students' attitudes along a novice-to-expert trajectory. Instrument use and learning assessment at the four partnering institutions is being supplemented by national-level outreach to engage further partners, using hands-on workshops and follow-on individual training and consultation for faculty who commit to pilot use in their own courses. \n The intellectual merit of the project lies in its well-formulated plan to leverage fixed-location, high-end analytical instruments to enable authentic research and inquiry within the undergraduate curriculum at remote institutions. The embedded educational research addresses important questions of a) how much and what type(s) of remote instrument-aided inquiry enable targeted student-learning outcomes, b) what factors determine effectiveness as institution type, curricular level, and student audiences vary, and c) what challenges exist for widespread propagation of the approach and how might these be overcome. Broader impacts of the project include a) the production of insights and practices that promote remote use of research-grade analytical instrumentation at multiple levels of the undergraduate curriculum, providing a model that could be used at other research centers to enable heretofore inaccessible analytical capabilities at a wide range of undergraduate institutions, b) engagement of a diverse range of students (from seniors in majors' classes to first-year non-majors in introductory classes) and institutions (from research universities to community colleges) in authentic research, a high-impact practice for retaining students in STEM disciplines, and c) professional development for faculty at the partnering institutions and beyond, as well as for a postdoctoral scholar and graduate student engaged in discipline-based educational research.",
-    "name": "Collaborative Project: Expanding the Use of Remote Electron Microscopy in the Classroom to Transform Undergraduate Geoscience Education",
-    "url": "https://nsf.gov/awardsearch/showAward?AWD_ID=1323354"
-  },
-  "keywords": "Hicks Butte complex, feldspar, Jurassic, plagioclase, dacite, tonalite, rhyolite",
-  "license": "http://creativecommons.org/licenses/by-sa-nc/3.0/",
-  "measurementTechnique": ["Electron Microprobe"],
-  "name": "Plagioclase data from the Hicks Butte Inlier, central Cascades, Washington, USA",
-  "provider": {
-        "@type": "Organization",
-        "@id": "https://www.iedadata.org/",
-        "name": "Interdisciplinary Earth Data Alliance (IEDA)"
-  },
-  "publisher": {
-    "@type": "Organization",
-         "@id": "https://www.iedadata.org/",
-        "name": "Interdisciplinary Earth Data Alliance (IEDA)",
-        "url": "https://www.iedadata.org/",
-        "description": "The IEDA data facility mission is to support, sustain, and advance the geosciences by providing data services for observational geoscience data from the Ocean, Earth, and Polar Sciences. IEDA systems serve as primary community data collections for global geochemistry and marine geoscience research and support the preservation, discovery, retrieval, and analysis of a wide range of observational field and analytical data types. Our tools and services are designed to facilitate data discovery and reuse for focused disciplinary research and to support interdisciplinary research and data integration.",
-        "logo": {
-            "@type": "ImageObject",
-            "url": ""
-        },
-        "contactPoint": {
-            "@type": "ContactPoint",
-            "name": "Kerstin Lehnert",
-            "email": "lehnert@ldeo.columbia.edu",
-            "url": "http://orcid.org/0000-0001-7036-1977",
-            "contactType": "Director"
-        },
-        "funder": {
-            "@type": "Organization",
-            "@id": "http://dx.doi.org/10.13039/100000085",
-            "legalName": "Directorate for Geosciences",
-            "alternateName": "NSF-GEO",
-            "url": "http://www.nsf.gov",
-            "parentOrganization": {
-                "@type": "Organization",
-                "@id": "http://dx.doi.org/10.13039/100000001",
-                "legalName": "National Science Foundation",
-                "alternateName": "NSF",
-                "url": "http://www.nsf.gov"
-            }
-        },
-        "parentOrganization": {
-            "@type": "Organization",
-            "@id": "https://viaf.org/viaf/142992181/",
-            "name": "Lamont-Doherty Earth Observatory",
-            "url": "http://www.ldeo.columbia.edu/",
-            "address": {
-                "@type": "PostalAddress",
-                "streetAddress": "61 Route 9W",
-                "addressLocality": "Palisades",
-                "addressRegion": "NY",
-                "postalCode": "10964-1000",
-                "addressCountry": "USA"
-            },
-            "parentOrganization": {
-                "@type": "Organization",
-                "@id": "https://viaf.org/viaf/156836332/",
-                "legalName": "Columbia University",
-                "url": "http://www.columbia.edu/"
-            }
-        },
-  "publishingPrinciples": {
-    "@id": "http://creativecommons.org/licenses/by-nc-sa/3.0/us/",
-    "@type": "DigitalDocument",
-    "additionalType": "gdx:Protocol-License",
-    "name": "Dataset Usage License",
-    "description":"Creative Commons Attribution-NonCommercial-Share Alike 3.0 United States [CC BY-NC-SA 3.0]",
-    "url": "https://creativecommons.org/licenses/by-nc-sa/3.0/us/"
-  }
-  },
-  "spatialCoverage": {
-    "@type": "Place",
-    "additionalProperty": [
-      {
-        "@type": "PropertyValue",
-        "alternateName": "CRS",
-        "name": "Coordinate Reference System",
-        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
-      }
-    ],
-    "geo": {
-      "@type": "GeoShape",
-      "box": "-149.8727,-17.45 -64.6353,34.407",
-      "polygon": "-149.8727,-17.45 -149.8727,34.407 -64.6353,34.407 -64.6353,-17.45 -149.8727,-17.45"
-    }
-  },
-  "variableMeasured": [
-    {
-      "@id": "https://www.bco-dmo.org/dataset-parameter/665785",
-      "@type": "PropertyValue",
-      "additionalType": "earthcollab:Parameter",
-      "description": "place holder",
-      "unitText": "unitless",
-      "url": "",
-      "value": "",
-      "valueReference": {
-        "@id": "...",
-        "@type": "PropertyValue",
-        "description": "...",
-        "unitText": "text",
-        "url": "...",
-        "value": ".."
-      }
-    } 
-  ]
+	"@context": {
+		"@vocab": "http://schema.org/",
+		"datacite": "http://purl.org/spar/datacite/",
+		"earthcollab": "https://library.ucar.edu/earthcollab/schema#",
+		"geolink": "http://schema.geolink.org/1.0/base/main#",
+		"vivo": "http://vivoweb.org/ontology/core#",
+		"dcat": "http://www.w3.org/ns/dcat#"
+	},
+	"@id": "doi:10.1594/IEDA/100599",
+	"@type": "Dataset",
+	"additionalType": ["geolink:Dataset",
+	"vivo:Dataset"],
+	"alternateName": "Plagioclase data from the Hicks Butte Inlier, central Cascades, Washington, USA",
+	"citation": "MacDonald, James H. (2016): Plagioclase data from the Hicks Butte Inlier, central Cascades, Washington, USA. EarthChem Library. http://dx.doi.org/10.1594/IEDA/100599",
+	"creator": [{
+		"@id": "https://orcid.org/0000-0001-7576-5575",
+		"@type": "Person",
+		"additionalType": "geolink:Person",
+		"name": "MacDonald, James H."
+	}],
+	"datePublished": "2016-06-15",
+	"description": "In this data set is plagioclase and amphibole data that was part of Thompson et al. (2015) Geological Society of America abstract. This data was generated at the Florida Center for Analytical Electron Microscopy, and was funded by NSF grant DUE 1323354.",
+	"distribution":[
+	 {
+		"@type": "DataDownload",
+		"additionalType": ["dcat:distribution"],
+		"dcat:accessURL": "http://grl.geoinfogeochem.org/downloadFeedback.php?id=952",
+		"datePublished": "2016-06-15",
+		"thumbnailUrl": "null",
+		"encodingFormat": "application/vnd.ms-excel",
+		"inLanguage": "en-US"
+	}
+	],
+	"identifier": [{
+		"@id": "doi:10.1594/IEDA/100599",
+		"@type": "PropertyValue",
+		"additionalType": ["geolink:Identifier",
+		"datacite:Identifier"],
+		"propertyID": "datacite:doi",
+		"url": "http://dx.doi.org/10.1594/IEDA/100599",
+		"value": "10.1594/IEDA/100599"
+	}],
+	"includedInDataCatalog": {
+		"@type": "DataCatalog",
+		"name": "Earthchem Library",
+		"url": "http://www.earthchem.org/library/search"
+	},
+	"isPartOf": {
+		"@id": "https://nsf.gov/awardsearch/showAward?AWD_ID=1323354",
+		"@type": "CreativeWork",
+		"additionalType": "earthcollab:Project",
+		"description": "This collaborative project is examining the remote operation of analytical instruments, specifically a scanning-electron microscope and electron microprobe analyzer housed at Florida International University (FIU), to facilitate inquiry-based approaches to learning in undergraduate geoscience courses. The effectiveness of remote instrument use is being assessed across different course levels and audiences at four diverse institutions: FIU, Valencia Community College, Florida Gulf Coast University, and the University of South Florida. Faculty at each institution are adapting instrument use to their courses and students, and using common methods to assess learning gains and changes in students' attitudes along a novice-to-expert trajectory. Instrument use and learning assessment at the four partnering institutions is being supplemented by national-level outreach to engage further partners, using hands-on workshops and follow-on individual training and consultation for faculty who commit to pilot use in their own courses. \n The intellectual merit of the project lies in its well-formulated plan to leverage fixed-location, high-end analytical instruments to enable authentic research and inquiry within the undergraduate curriculum at remote institutions. The embedded educational research addresses important questions of a) how much and what type(s) of remote instrument-aided inquiry enable targeted student-learning outcomes, b) what factors determine effectiveness as institution type, curricular level, and student audiences vary, and c) what challenges exist for widespread propagation of the approach and how might these be overcome. Broader impacts of the project include a) the production of insights and practices that promote remote use of research-grade analytical instrumentation at multiple levels of the undergraduate curriculum, providing a model that could be used at other research centers to enable heretofore inaccessible analytical capabilities at a wide range of undergraduate institutions, b) engagement of a diverse range of students (from seniors in majors' classes to first-year non-majors in introductory classes) and institutions (from research universities to community colleges) in authentic research, a high-impact practice for retaining students in STEM disciplines, and c) professional development for faculty at the partnering institutions and beyond, as well as for a postdoctoral scholar and graduate student engaged in discipline-based educational research.",
+		"name": "Collaborative Project: Expanding the Use of Remote Electron Microscopy in the Classroom to Transform Undergraduate Geoscience Education",
+		"url": "https://nsf.gov/awardsearch/showAward?AWD_ID=1323354"
+	},
+	"keywords": ["Hicks Butte complex",
+	"feldspar",
+	"Jurassic",
+	"plagioclase",
+	"dacite",
+	"tonalite",
+	"rhyolite"],
+	"license": "http://creativecommons.org/licenses/by-sa-nc/3.0/",
+	"measurementTechnique": ["Electron Microprobe"],
+	"name": "Plagioclase data from the Hicks Butte Inlier, central Cascades, Washington, USA",
+	"provider": {
+		"@type": "Organization",
+		"@id": "https://www.iedadata.org/",
+		"name": "Interdisciplinary Earth Data Alliance (IEDA)"
+	},
+	"publisher": {
+		"@type": "Organization",
+		"@id": "https://www.iedadata.org/",
+		"name": "Interdisciplinary Earth Data Alliance (IEDA)",
+		"url": "https://www.iedadata.org/",
+		"description": "The IEDA data facility mission is to support, sustain, and advance the geosciences by providing data services for observational geoscience data from the Ocean, Earth, and Polar Sciences. IEDA systems serve as primary community data collections for global geochemistry and marine geoscience research and support the preservation, discovery, retrieval, and analysis of a wide range of observational field and analytical data types. Our tools and services are designed to facilitate data discovery and reuse for focused disciplinary research and to support interdisciplinary research and data integration.",
+		"logo": {
+			"@type": "ImageObject",
+			"url": ""
+		},
+		"contactPoint": {
+			"@type": "ContactPoint",
+			"name": "Kerstin Lehnert",
+			"email": "lehnert@ldeo.columbia.edu",
+			"url": "http://orcid.org/0000-0001-7036-1977",
+			"contactType": "Director"
+		},
+		"funder": {
+			"@type": "Organization",
+			"@id": "http://dx.doi.org/10.13039/100000085",
+			"legalName": "Directorate for Geosciences",
+			"alternateName": "NSF-GEO",
+			"url": "http://www.nsf.gov",
+			"parentOrganization": {
+				"@type": "Organization",
+				"@id": "http://dx.doi.org/10.13039/100000001",
+				"legalName": "National Science Foundation",
+				"alternateName": "NSF",
+				"url": "http://www.nsf.gov"
+			}
+		},
+		"parentOrganization": {
+			"@type": "Organization",
+			"@id": "https://viaf.org/viaf/142992181/",
+			"name": "Lamont-Doherty Earth Observatory",
+			"url": "http://www.ldeo.columbia.edu/",
+			"address": {
+				"@type": "PostalAddress",
+				"streetAddress": "61 Route 9W",
+				"addressLocality": "Palisades",
+				"addressRegion": "NY",
+				"postalCode": "10964-1000",
+				"addressCountry": "USA"
+			},
+			"parentOrganization": {
+				"@type": "Organization",
+				"@id": "https://viaf.org/viaf/156836332/",
+				"legalName": "Columbia University",
+				"url": "http://www.columbia.edu/"
+			}
+		},
+		"publishingPrinciples": {
+			"@id": "http://creativecommons.org/licenses/by-nc-sa/3.0/us/",
+			"@type": "DigitalDocument",
+			"additionalType": "gdx:Protocol-License",
+			"name": "Dataset Usage License",
+			"description": "Creative Commons Attribution-NonCommercial-Share Alike 3.0 United States [CC BY-NC-SA 3.0]",
+			"url": "https://creativecommons.org/licenses/by-nc-sa/3.0/us/"
+		}
+	},
+	"spatialCoverage": [{
+		"@type": "Place",
+		"additionalProperty": [{
+			"@type": "PropertyValue",
+			"alternateName": "CRS",
+			"name": "Coordinate Reference System",
+			"value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+		}],
+		"geo": {
+			"@type": "GeoShape",
+			"box": "-149.8727,-17.45 -64.6353,34.407",
+			"polygon": "-149.8727,-17.45 -149.8727,34.407 -64.6353,34.407 -64.6353,-17.45 -149.8727,-17.45"
+		}
+	}],
+	"variableMeasured": [{
+		"@id": "https://www.bco-dmo.org/dataset-parameter/665785",
+		"@type": "PropertyValue",
+		"additionalType": "earthcollab:Parameter",
+		"description": "place holder",
+		"unitText": "unitless",
+		"url": "",
+		"value": "",
+		"valueReference": {
+			"@id": "...",
+			"@type": "PropertyValue",
+			"description": "...",
+			"unitText": "text",
+			"url": "...",
+			"value": ".."
+		}
+	}]
 }

--- a/examples/EarthChem952-1.jsonld
+++ b/examples/EarthChem952-1.jsonld
@@ -47,12 +47,12 @@
       "value": "10.1594/IEDA/100599"
     }
   ],
-  "includedInDataCatalog": { //expects DataCatalog
+  "includedInDataCatalog": { 
     "@type":"DataCatalog",
     "name":"Earthchem Library",
     "url": "http://www.earthchem.org/library/search"
   },
-  "isPartOf": { //project context
+  "isPartOf": { 
     "@id": "https://nsf.gov/awardsearch/showAward?AWD_ID=1323354",
     "@type": "CreativeWork",
     "additionalType": "earthcollab:Project",
@@ -127,8 +127,8 @@
     "name": "Dataset Usage License",
     "description":"Creative Commons Attribution-NonCommercial-Share Alike 3.0 United States [CC BY-NC-SA 3.0]",
     "url": "https://creativecommons.org/licenses/by-nc-sa/3.0/us/"
+  }
   },
-  "recordedAt": "missing",
   "spatialCoverage": {
     "@type": "Place",
     "additionalProperty": [
@@ -143,11 +143,6 @@
       "@type": "GeoShape",
       "box": "-149.8727,-17.45 -64.6353,34.407",
       "polygon": "-149.8727,-17.45 -149.8727,34.407 -64.6353,34.407 -64.6353,-17.45 -149.8727,-17.45"
-    },
-    "subjectOf": {
-      "@type": "CreativeWork",
-      "fileFormat": "application/vnd.geo+json",
-      "text": "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[\"-64.635300000000\",\"34.407000000000\"],[\"-64.635300000000\",\"-17.450000000000\"],[\"-149.872700000000\",\"-17.450000000000\"],[\"-149.872700000000\",\"34.407000000000\"],[\"-64.635300000000\",\"34.407000000000\"]]]}}"
     }
   },
   "variableMeasured": [
@@ -169,5 +164,4 @@
       }
     } 
   ]
-}
 }

--- a/examples/IEDA-USAPrepo.jsonld
+++ b/examples/IEDA-USAPrepo.jsonld
@@ -1,0 +1,134 @@
+{
+    "@context": {
+        "@vocab": "http://schema.org/",
+        "gdx": "https://geodex.org/voc/"
+    },
+    "@type": [
+        "Service",
+        "Organization"
+    ],
+    "@id": "http://doi.org/10.17616/R31898",
+    "additionalType": "gdx:ResearchRepositoryService",
+    "name": "U.S. Antarctic Program Data Center",
+    "url": "http://www.usap-dc.org/index",
+    "category": ["Earth Science, Polar Science"],
+    "description": "The U.S. Antarctic Program Data Center (USAP-DC) supports investigators funded by the National Science Foundation in documenting, preserving, and disseminating their research results. We register datasets in the Antarctic Master Directory (AMD) to comply with the Antarctic Treaty; facilitate submission of datasets to long-term archives; and represent the U.S. in Scientific Committee on Antarctic Research (SCAR) activities. USAP-DC is a member of the Interdisciplinary Earth Data Alliance (IEDA) and the Antarctic and Arctic Data Consortium (A2DC). As of 2016, USAP-DC is now partnered with the National Snow and Ice Data Center (NSIDC) to manage glaciology data for the US Antarctic Program.",
+    "sameAs": "https://www.re3data.org/repository/r3d100010660",
+    "identifier": {
+        "@type": "PropertyValue",
+        "propertyID": "http://purl.org/spar/datacite/doi",
+        "value": "10.17616/R31898",
+        "url": "http://doi.org/10.17616/R31898"
+    },
+    "contactPoint": {
+        "@type": "ContactPoint",
+        "name": "USAP-DC Manager",
+        "email": "info@usap-dc.org",
+        "url": "http://www.usap-dc.org/contact",
+        "contactType": "Information"
+    },
+    "funder": {
+        "@type": "Organization",
+        "@id": "http://dx.doi.org/10.13039/100000087",
+        "legalName": "Division Of Polar Programs",
+        "alternateName": "NSF-OPP",
+        "url": "http://www.nsf.gov",
+        "parentOrganization": {
+            "@type": "Organization",
+            "@id": "http://dx.doi.org/10.13039/100000001",
+            "legalName": "National Science Foundation",
+            "alternateName": "NSF",
+            "url": "http://www.nsf.gov"
+        }
+    },
+    "logo": {
+        "@type": "ImageObject",
+        "url": "https://www.iedadata.org/wp-content/themes/IEDA/assets/img/logo.png"
+    },
+    "publishingPrinciples": {
+        "@type": "DigitalDocument",
+        "@id": "https://www.iedadata.org/help/data-publication/",
+        "additionalType": "gdx:Protocol-TermsOfUse",
+        "name": "Data Publication Policy",
+        "url": "https://www.iedadata.org/help/data-publication/",
+        "fileFormat": "text/html"
+    },
+    "parentOrganization": {
+        "@type": "Organization",
+        "@id": "https://www.iedadata.org/",
+        "name": "Interdisciplinary Earth Data Alliance (IEDA)",
+        "url": "https://www.iedadata.org/",
+        "description": "The IEDA data facilitys mission is to support, sustain, and advance the geosciences by providing data services for observational geoscience data from the Ocean, Earth, and Polar Sciences. IEDA systems serve as primary community data collections for global geochemistry and marine geoscience research and support the preservation, discovery, retrieval, and analysis of a wide range of observational field and analytical data types. Our tools and services are designed to facilitate data discovery and reuse for focused disciplinary research and to support interdisciplinary research and data integration.",
+        "logo": {
+            "@type": "ImageObject",
+            "url": "https://www.iedadata.org/wp-content/themes/IEDA/assets/img/logo.png"
+        },
+        "parentOrganization": {
+            "@type": "Organization",
+            "@id": "https://viaf.org/viaf/142992181/",
+            "name": "Lamont-Doherty Earth Observatory",
+            "url": "http://www.ldeo.columbia.edu/",
+            "address": {
+                "@type": "PostalAddress",
+                "streetAddress": "61 Route 9W",
+                "addressLocality": "Palisades",
+                "addressRegion": "NY",
+                "postalCode": "10964-1000",
+                "addressCountry": "USA"
+            },
+            "parentOrganization": {
+                "@type": "Organization",
+                "@id": "https://viaf.org/viaf/156836332/",
+                "legalName": "Columbia University",
+                "url": "http://www.columbia.edu/"
+            }
+        }
+    },
+    "hasOfferCatalog": {
+        "@type": "OfferCatalog",
+        "name": "USAP-DC Catalog",
+        "itemListElement": [{
+            "@type": "DataCatalog",
+            "@id": "http://www.usap-dc.org/search",
+            "name": "US Antarctic Program Data Center Catlog",
+            "audience": {
+                "@type": "Audience",
+                "audienceType": "public",
+                "name": "General Public"
+            }
+        }]
+    },
+    "availableChannel": [
+        {
+            "@type": "ServiceChannel",
+            "serviceUrl": "http://www.earthchem.org/library/search",
+            "providesService": {
+                "@type": "Service",
+                "@id": "http://www.earthchem.org/library/search",
+                "additionalType": "gdx:SearchService",
+                "name": "EarthChem Library Search",
+                "description": "Search for datasets in the EarthChem Library repository",
+                "potentialAction": {
+                    "@type": "SearchAction",
+                    "target": "http://www.earthchem.org/library/search"
+                }
+            }
+        },
+        {
+            "@type": "ServiceChannel",
+            "availableLanguage": "en-US",
+            "serviceUrl": "http://www.usap-dc.org/submit",
+            "providesService": {
+                "@type": "Service",
+                "@id": "http://www.usap-dc.org/submit",
+                "additionalType": "gdx:SubmissionService",
+                "name": "Submit Data to US Antarctic Program Data Center",
+                "description": "Web application to support submitting a dataset to USAP-DC or Registering a project with the Antarctic Master Directory. Requires a sign in using Google or ORCID (free registration). Datasets will be registered with a DOI after acceptance for accession to repository.",
+                "potentialAction": {
+                    "@type": "CreateAction",
+                    "target": "http://www.earthchem.org/library/submit"
+                }
+            }
+        }
+    ]
+}

--- a/examples/potentialAction-availableChannel-compare.txt
+++ b/examples/potentialAction-availableChannel-compare.txt
@@ -1,0 +1,53 @@
+ Service approach, from current (2018-01-15) bco-dmo.org JSONLD---
+"Service".....
+ "availableChannel": 
+        {
+            "@type": "ServiceChannel",
+            "serviceUrl": "https://www.bco-dmo.org/search",
+            "providesService": {
+                "@type": "Service",
+                "@id": "https://www.bco-dmo.org/search",
+                "additionalType": "gdx:SearchService",
+                "name": "BCO-DMO Website Search",
+                "description": "Search for webpages, datasets, people, projects, funding awards, deployments, instrumentation and measurements",
+                "potentialAction": {
+                    "@type": "SearchAction",
+                    "target": "https://www.bco-dmo.org/search?keywords={query_string}",
+                    "query-input": {
+                        "@type": "PropertyValueSpecification",
+                        "valueRequired": true,
+                        "valueName": "query_string"
+                    }
+                }
+            }
+        },
+NOTES.
+"target"  value should be type EntryPoint (https://pending.schema.org/target)		
+Adds several levels of nesting before getting to the URL template:
+Service.availableChannel-->ServiceChannel.providesService-->Service.potentialAction-->SearchAction.target--EntryPoint.urlTemplate
+Since Service is a Thing, it has potentialAction, so this could be constructed using the same approach as Organization.  The question is, what benefit is gained by the ServiceChannel and intermediary Service classes?
+
+	
+	
+Organization approach, based on EarthCube CDF project examples---
+"Organization"....
+    "potentialAction": 
+        {
+            "@type": "SearchAction",
+			"additionalType": "gdx:SearchService",
+            "name":"IEDA Integrated Catalog Search",
+			"description": "Search the IEDA integrated catalog. search_term_string is used for a free text search of Titles, Abstracts and Keywords in the catalog.",
+            "target": {
+                "@type": "EntryPoint",
+                "urlTemplate": "http://catalog-dev.iedadata.org:8080/geoportal/?q={search_term_string}",
+                "query-input": {
+                        "@type": "PropertyValueSpecification",
+                        "valueRequired": true,
+                        "valueName": "search_term_string"
+                        },
+                "httpMethod": "GET"
+            }
+        }
+
+Fewer levels of nesting
+Organization(or Service).potentialAction --> SearchAction.target --> EntryPoint.urlTemplate


### PR DESCRIPTION
directory with xml transform and example output. Work with Datacite v2, v3, v4. Tested with IEDA datacite records and a few xml records pulled from DataCite.  Content consistent with datacite JSONLD output, see readme for list of differences. 